### PR TITLE
Refactor code check: reusable lint workflow & composite actions

### DIFF
--- a/.github/actions/check-reproducer/action.yml
+++ b/.github/actions/check-reproducer/action.yml
@@ -1,0 +1,135 @@
+name: check-reproducer
+description: |
+  Validate that an AI-generated PR includes pytest-style reproducer files
+  under `test/repro/test_*.py`. On failure, post a comment on the PR (when a
+  GitHub token is available) and fail the step with a clear annotation.
+
+inputs:
+  working-directory:
+    description: Path to the repository checkout containing `test/repro/`.
+    required: false
+    default: '.'
+  reproducer-glob:
+    description: Glob (relative to working-directory) for reproducer files.
+    required: false
+    default: 'test/repro/test_*.py'
+  pr-number:
+    description: Pull request number for posting comments. Defaults to current PR.
+    required: false
+    default: ${{ github.event.pull_request.number }}
+  pr-author:
+    description: PR author login (used to @-mention in the comment).
+    required: false
+    default: ${{ github.event.pull_request.user.login }}
+  comment-on-failure:
+    description: Whether to post a PR comment when validation fails.
+    required: false
+    default: 'true'
+  github-token:
+    description: |
+      Token used to post the failure comment. If empty, the comment step is
+      skipped (the step still fails).
+    required: false
+    default: ''
+
+outputs:
+  ok:
+    description: '"true" if reproducers exist and are valid, "false" otherwise.'
+    value: ${{ steps.validate.outputs.ok }}
+  reason:
+    description: Failure reason (empty on success).
+    value: ${{ steps.validate.outputs.reason }}
+
+runs:
+  using: composite
+  steps:
+    - name: Validate reproducer files
+      id: validate
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        REPRO_GLOB: ${{ inputs.reproducer-glob }}
+      run: |
+        set -uo pipefail
+        ok=true
+        reason=""
+        files=()
+
+        # Collect files (nullglob-safe).
+        shopt -s nullglob
+        for f in ${REPRO_GLOB}; do
+          files+=("$f")
+        done
+        shopt -u nullglob
+
+        if [[ ${#files[@]} -eq 0 ]]; then
+          ok=false
+          reason="No reproducer test found. AI-generated PRs must include at least one reproducer matching \`${REPRO_GLOB}\`."
+        else
+          for f in "${files[@]}"; do
+            if ! grep -qE '^[[:space:]]*(def test_|class Test)' "$f"; then
+              ok=false
+              reason="Reproducer \`$f\` is not in pytest format. It must contain pytest-style test functions (\`def test_...\`) or test classes (\`class Test...\`)."
+              break
+            fi
+          done
+        fi
+
+        if [[ "${ok}" == "true" ]]; then
+          echo "All reproducer tests are valid pytest format:"
+          printf '  - %s\n' "${files[@]}"
+          {
+            echo "## Reproducer check"
+            echo
+            echo "✅ Found ${#files[@]} valid reproducer file(s):"
+            for f in "${files[@]}"; do echo "- \`$f\`"; done
+          } >> "${GITHUB_STEP_SUMMARY:-/dev/null}" || true
+        else
+          {
+            echo "## Reproducer check"
+            echo
+            echo "❌ ${reason}"
+          } >> "${GITHUB_STEP_SUMMARY:-/dev/null}" || true
+        fi
+
+        echo "ok=${ok}"           >> "${GITHUB_OUTPUT}"
+        # Use heredoc-style multi-line output for safety with special chars.
+        {
+          echo "reason<<__REASON_EOF__"
+          echo "${reason}"
+          echo "__REASON_EOF__"
+        } >> "${GITHUB_OUTPUT}"
+
+    - name: Comment on PR
+      if: ${{ steps.validate.outputs.ok != 'true' && inputs.comment-on-failure == 'true' && inputs.github-token != '' }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        PR_AUTHOR: ${{ inputs.pr-author }}
+        REASON: ${{ steps.validate.outputs.reason }}
+      run: |
+        set -euo pipefail
+        if [[ -z "${PR_NUMBER}" ]]; then
+          echo "::warning::No PR number available, skipping comment."
+          exit 0
+        fi
+        body=$(cat <<EOF
+        @${PR_AUTHOR} ${REASON}
+
+        Please ensure your reproducer follows pytest conventions:
+        - File name: \`test/repro/test_<description>.py\`
+        - Contains \`def test_...()\` functions or \`class Test...\` classes
+        - Runnable via \`pytest test/repro/\`
+        EOF
+        )
+        gh pr comment "${PR_NUMBER}" --body "${body}"
+
+    - name: Fail step on invalid reproducer
+      if: ${{ steps.validate.outputs.ok != 'true' }}
+      shell: bash
+      env:
+        REASON: ${{ steps.validate.outputs.reason }}
+      run: |
+        echo "::error title=Reproducer check failed::${REASON}"
+        exit 1

--- a/.github/actions/code-check/action.yml
+++ b/.github/actions/code-check/action.yml
@@ -1,0 +1,106 @@
+name: code-check
+description: |
+  Run lintrunner-based code checks (lint / clang-format / clang-tidy) with a
+  consistent setup, structured GitHub annotations, and a step summary.
+
+inputs:
+  scope:
+    description: |
+      Which check to run. One of:
+        - `lint`         : everything except clang-format/clang-tidy/CSV merge
+        - `clang-format` : CLANGFORMAT only
+        - `clang-tidy`   : CLANGTIDY only (requires a built source tree)
+        - `custom`       : pass `lintrunner-args` verbatim
+    required: true
+    default: lint
+  lintrunner-args:
+    description: Additional arguments forwarded to `lintrunner` (used when scope=custom or to override).
+    required: false
+    default: ''
+  python-version:
+    description: Python interpreter to use for the lint venv.
+    required: false
+    default: '3.10'
+  working-directory:
+    description: Directory to run the lint check from.
+    required: false
+    default: '.'
+  upload-artifact:
+    description: Whether to upload `lint.json` as a workflow artifact.
+    required: false
+    default: 'true'
+  artifact-name:
+    description: Name of the uploaded artifact (defaults to `lint-<scope>`).
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve lintrunner args
+      id: args
+      shell: bash
+      env:
+        SCOPE: ${{ inputs.scope }}
+        EXTRA: ${{ inputs.lintrunner-args }}
+      run: |
+        set -euo pipefail
+        case "${SCOPE}" in
+          lint)
+            args="--skip CLANGTIDY,CLANGFORMAT,MERGE_CONFLICTLESS_CSV --all-files"
+            ;;
+          clang-format)
+            args="--take CLANGFORMAT --all-files"
+            ;;
+          clang-tidy)
+            args="--take CLANGTIDY --all-files"
+            ;;
+          custom)
+            if [[ -z "${EXTRA}" ]]; then
+              echo "::error::scope=custom requires non-empty 'lintrunner-args'"
+              exit 1
+            fi
+            args=""
+            ;;
+          *)
+            echo "::error::Unknown scope '${SCOPE}'. Expected: lint | clang-format | clang-tidy | custom"
+            exit 1
+            ;;
+        esac
+        # Append any additional user args.
+        if [[ -n "${EXTRA}" ]]; then
+          args="${args} ${EXTRA}"
+        fi
+        echo "args=${args}" >> "${GITHUB_OUTPUT}"
+
+    - name: Run code-check (${{ inputs.scope }})
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        ADDITIONAL_LINTRUNNER_ARGS: ${{ steps.args.outputs.args }}
+        LINT_PYTHON_VERSION: ${{ inputs.python-version }}
+        CLANG: ${{ inputs.scope == 'clang-tidy' && '1' || '0' }}
+      run: bash .github/scripts/lintrunner.sh
+
+    - name: Resolve artifact name
+      id: artifact
+      if: ${{ always() && inputs.upload-artifact == 'true' }}
+      shell: bash
+      env:
+        SCOPE: ${{ inputs.scope }}
+        NAME: ${{ inputs.artifact-name }}
+      run: |
+        if [[ -n "${NAME}" ]]; then
+          echo "name=${NAME}" >> "${GITHUB_OUTPUT}"
+        else
+          echo "name=lint-${SCOPE}" >> "${GITHUB_OUTPUT}"
+        fi
+
+    - name: Upload lint.json
+      if: ${{ always() && inputs.upload-artifact == 'true' }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ steps.artifact.outputs.name }}
+        path: ${{ inputs.working-directory }}/lint.json
+        if-no-files-found: ignore
+        retention-days: 7

--- a/.github/scripts/lintrunner.sh
+++ b/.github/scripts/lintrunner.sh
@@ -1,67 +1,150 @@
 #!/usr/bin/env bash
-set -ex
+# Run lintrunner with consistent setup, structured output, and a GitHub step summary.
+#
+# Environment variables (all optional):
+#   LINT_PYTHON_VERSION       Python interpreter for the lint venv (default: 3.10)
+#   LINT_VENV_DIR             Directory for the venv                (default: lint)
+#   LINT_CACHE_DIR            Cache for downloaded linter binaries  (default: /tmp/.lintbin)
+#   ADDITIONAL_LINTRUNNER_ARGS  Extra args forwarded to `lintrunner`
+#   CLANG                     If "1", run clang-tidy build-file generator
+#   GITHUB_STEP_SUMMARY       Auto-set in GitHub Actions; appended to if present.
 
-# Creat a venv for lint check
-if ! uv --help > /dev/null 2>&1; then
+set -euo pipefail
+
+LINT_PYTHON_VERSION="${LINT_PYTHON_VERSION:-3.10}"
+LINT_VENV_DIR="${LINT_VENV_DIR:-lint}"
+LINT_CACHE_DIR="${LINT_CACHE_DIR:-/tmp/.lintbin}"
+ADDITIONAL_LINTRUNNER_ARGS="${ADDITIONAL_LINTRUNNER_ARGS:-}"
+
+log()   { printf '\033[1;36m[lint]\033[0m %s\n' "$*"; }
+warn()  { printf '\033[1;33m[lint][warn]\033[0m %s\n' "$*" >&2; }
+error() { printf '\033[1;31m[lint][error]\033[0m %s\n' "$*" >&2; }
+
+# Append to the GitHub step summary if available.
+summary() {
+    if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+        printf '%s\n' "$*" >> "${GITHUB_STEP_SUMMARY}"
+    fi
+}
+
+# ── Bootstrap uv ─────────────────────────────────────────────────────────────
+if ! command -v uv > /dev/null 2>&1; then
+    log "Installing uv"
     curl -LsSf https://astral.sh/uv/install.sh | sh
-    export PATH="$PATH:$HOME/.local/bin"
-fi
-uv venv lint --python 3.10 --clear
-source lint/bin/activate
-uv pip install -U pip setuptools==81.0.0 wheel pyyaml typing-extensions
-
-# Use uv to speed up lintrunner init
-uv pip install ruamel.yaml
-
-CACHE_DIRECTORY="/tmp/.lintbin"
-# Try to recover the cached binaries
-if [[ -d "${CACHE_DIRECTORY}" ]]; then
-    # It's ok to fail this as lintrunner init would download these binaries
-    # again if they do not exist
-    cp -r "${CACHE_DIRECTORY}" . || true
+    export PATH="${HOME}/.local/bin:${PATH}"
 fi
 
-# if lintrunner is not installed, install it
-if ! command -v lintrunner &> /dev/null; then
-    uv pip install lintrunner
+# ── Create venv ──────────────────────────────────────────────────────────────
+log "Creating lint venv (python=${LINT_PYTHON_VERSION}) at ${LINT_VENV_DIR}"
+uv venv "${LINT_VENV_DIR}" --python "${LINT_PYTHON_VERSION}" --clear
+# shellcheck disable=SC1091
+source "${LINT_VENV_DIR}/bin/activate"
+
+log "Installing base dependencies"
+uv pip install --quiet -U pip 'setuptools==81.0.0' wheel pyyaml typing-extensions ruamel.yaml
+
+if ! command -v lintrunner > /dev/null 2>&1; then
+    log "Installing lintrunner"
+    uv pip install --quiet lintrunner
 fi
 
-# Ignoring errors in one specific run
-export SHELLCHECK_OPTS="-e SC2154 -e SC2086 -e SC1091 -e SC2046 -e SC2076 -e SC2034 -e SC2190"
+# ── Restore linter binary cache (best-effort) ───────────────────────────────
+if [[ -d "${LINT_CACHE_DIR}" ]]; then
+    log "Restoring linter cache from ${LINT_CACHE_DIR}"
+    cp -r "${LINT_CACHE_DIR}" .lintbin || warn "failed to restore lint cache (will redownload)"
+fi
 
-# This has already been cached in the docker image
-lintrunner init 2> /dev/null
+# Suppress noisy shellcheck rules across the repository.
+export SHELLCHECK_OPTS="${SHELLCHECK_OPTS:--e SC2154 -e SC2086 -e SC1091 -e SC2046 -e SC2076 -e SC2034 -e SC2190}"
 
-# Do build steps necessary for linters
-if [[ "${CLANG}" == "1" ]]; then
-    if [[ -e "third_party/torch-xpu-ops/tools/linter/clang_tidy/generate_build_files.py" ]];then
-        python3 third_party/torch-xpu-ops/tools/linter/clang_tidy/generate_build_files.py
+# ── Initialize linters ──────────────────────────────────────────────────────
+log "Running 'lintrunner init'"
+if ! lintrunner init; then
+    error "lintrunner init failed"
+    summary "❌ \`lintrunner init\` failed. Check job logs."
+    exit 1
+fi
+
+# ── clang-tidy build prep (optional) ────────────────────────────────────────
+if [[ "${CLANG:-0}" == "1" ]]; then
+    gen_script="third_party/torch-xpu-ops/tools/linter/clang_tidy/generate_build_files.py"
+    if [[ -e "${gen_script}" ]]; then
+        log "Generating clang-tidy build files"
+        python3 "${gen_script}"
     else
-        echo "Please run the checker under pytorch source code folder"
+        warn "CLANG=1 but ${gen_script} not found; run from the pytorch source folder"
     fi
 fi
-#uv tools.generate_torch_version --is_debug=false
-#uv tools.pyi.gen_pyi \
-#    --native-functions-path aten/src/ATen/native/native_functions.yaml \
-#    --tags-path aten/src/ATen/native/tags.yaml \
-#    --deprecated-functions-path "tools/autograd/deprecated.yaml"
-#python3 torch/utils/data/datapipes/gen_pyi.py
 
-RC=0
-# Run lintrunner on all files
-# Remove lint.json from a previous run to avoid lintrunner failing with "File exists" error
+# ── Run lintrunner ──────────────────────────────────────────────────────────
 rm -f lint.json
-if ! lintrunner --force-color --tee-json=lint.json ${ADDITIONAL_LINTRUNNER_ARGS} 2> /dev/null; then
-    echo ""
-    echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner -m origin/main\`. (If you don't get the same results, run \'lintrunner init\' to update your local linter)\e[0m"
-    echo -e "\e[1m\e[36mSee https://github.com/pytorch/pytorch/wiki/lintrunner for setup instructions. To apply suggested patches automatically, use the -a flag. Before pushing another commit,\e[0m"
-    echo -e "\e[1m\e[36mplease verify locally and ensure everything passes.\e[0m"
-    RC=1
+
+log "Running lintrunner ${ADDITIONAL_LINTRUNNER_ARGS}"
+RC=0
+# shellcheck disable=SC2086
+lintrunner --force-color --tee-json=lint.json ${ADDITIONAL_LINTRUNNER_ARGS} || RC=$?
+
+if [[ ${RC} -ne 0 ]]; then
+    cat <<'EOF' >&2
+
+────────────────────────────────────────────────────────────────────────
+Lint check failed. To reproduce locally:
+  lintrunner -m origin/main
+To auto-fix:
+  lintrunner -a
+See https://github.com/pytorch/pytorch/wiki/lintrunner for setup.
+────────────────────────────────────────────────────────────────────────
+EOF
 fi
 
-# Use jq to massage the JSON lint output into GitHub Actions workflow commands.
-jq --raw-output \
-    '"::\(if .severity == "advice" or .severity == "disabled" then "warning" else .severity end) file=\(.path),line=\(.line),col=\(.char),title=\(.code) \(.name)::" + (.description | gsub("\\n"; "%0A"))' \
-    lint.json || true
+# ── Emit GitHub annotations from lint.json ──────────────────────────────────
+if [[ -s lint.json ]] && command -v jq > /dev/null 2>&1; then
+    jq --raw-output '
+        "::\(if .severity == "advice" or .severity == "disabled" then "warning" else .severity end) " +
+        "file=\(.path),line=\(.line),col=\(.char),title=\(.code) \(.name)::" +
+        (.description | gsub("\\n"; "%0A"))
+    ' lint.json || true
+fi
 
-exit $RC
+# ── Step summary ────────────────────────────────────────────────────────────
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    summary "## Lint results"
+    summary ""
+    if [[ -s lint.json ]] && command -v jq > /dev/null 2>&1; then
+        total=$(wc -l < lint.json | tr -d ' ')
+        errors=$(jq -r 'select(.severity == "error") | .code' lint.json 2>/dev/null | wc -l | tr -d ' ')
+        warnings=$(jq -r 'select(.severity == "warning" or .severity == "advice") | .code' lint.json 2>/dev/null | wc -l | tr -d ' ')
+
+        summary "| Status | Count |"
+        summary "|--------|-------|"
+        summary "| Errors | ${errors} |"
+        summary "| Warnings | ${warnings} |"
+        summary "| Total findings | ${total} |"
+        summary ""
+
+        if [[ "${total}" != "0" ]]; then
+            summary "<details><summary>Top findings</summary>"
+            summary ""
+            summary '| Severity | File | Line | Code | Message |'
+            summary '|----------|------|------|------|---------|'
+            jq -r --arg sep '|' '
+                [.severity, .path, (.line|tostring), .code, ((.name // "") + ": " + ((.description // "") | gsub("\\n"; " ") | .[0:120]))]
+                | "| " + join(" | ") + " |"
+            ' lint.json 2>/dev/null | head -n 50 >> "${GITHUB_STEP_SUMMARY}" || true
+            summary ""
+            summary "</details>"
+        fi
+    else
+        summary "No lint findings."
+    fi
+
+    if [[ ${RC} -eq 0 ]]; then
+        summary ""
+        summary "✅ Lint passed."
+    else
+        summary ""
+        summary "❌ Lint failed — see annotations and the **Top findings** table above."
+    fi
+fi
+
+exit ${RC}

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -1,0 +1,116 @@
+name: lint
+
+# Reusable code-check workflow.
+#
+# Runs lint (always), clang-format (always), clang-tidy (opt-in), and the
+# AI-generated reproducer check (when requested). Each is a separate job for
+# parallelism and clear pass/fail signal in the GitHub UI.
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: Runner label.
+        required: false
+        type: string
+        default: ubuntu-24.04
+      python-version:
+        description: Python interpreter for the lint venv.
+        required: false
+        type: string
+        default: '3.10'
+      run-clang-tidy:
+        description: Whether to run clang-tidy (requires built sources).
+        required: false
+        type: boolean
+        default: false
+      check-reproducer:
+        description: Whether to run the AI-generated PR reproducer check.
+        required: false
+        type: boolean
+        default: false
+      checkout-path:
+        description: Path under $GITHUB_WORKSPACE to checkout into.
+        required: false
+        type: string
+        default: '.'
+    secrets:
+      github-token:
+        description: Token for posting reproducer-check comments on PRs.
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          path: ${{ inputs.checkout-path }}
+      - name: Run lint
+        uses: ./.github/actions/code-check
+        with:
+          scope: lint
+          python-version: ${{ inputs.python-version }}
+          working-directory: ${{ inputs.checkout-path }}
+          artifact-name: lint-findings
+
+  clang-format:
+    name: clang-format
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          path: ${{ inputs.checkout-path }}
+      - name: Run clang-format
+        uses: ./.github/actions/code-check
+        with:
+          scope: clang-format
+          python-version: ${{ inputs.python-version }}
+          working-directory: ${{ inputs.checkout-path }}
+          artifact-name: clang-format-findings
+
+  clang-tidy:
+    name: clang-tidy
+    if: ${{ inputs.run-clang-tidy }}
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          path: ${{ inputs.checkout-path }}
+      - name: Run clang-tidy
+        uses: ./.github/actions/code-check
+        with:
+          scope: clang-tidy
+          python-version: ${{ inputs.python-version }}
+          working-directory: ${{ inputs.checkout-path }}
+          artifact-name: clang-tidy-findings
+
+  reproducer:
+    name: reproducer
+    if: ${{ inputs.check-reproducer }}
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          path: ${{ inputs.checkout-path }}
+      - name: Validate reproducer
+        uses: ./.github/actions/check-reproducer
+        with:
+          working-directory: ${{ inputs.checkout-path }}
+          github-token: ${{ secrets.github-token }}

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -13,65 +13,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Lint
+  # Lint, clang-format, and (for AI-generated PRs) reproducer validation.
   preci-lint-check:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 30
     permissions:
       contents: read
+      pull-requests: write
       issues: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Run basic lint checks
-        run: |
-          export ADDITIONAL_LINTRUNNER_ARGS="--skip CLANGTIDY,CLANGFORMAT,MERGE_CONFLICTLESS_CSV --all-files"
-          bash .github/scripts/lintrunner.sh
-
-      - name: Run clang format checks
-        run: |
-          export ADDITIONAL_LINTRUNNER_ARGS="--take CLANGFORMAT --all-files"
-          bash .github/scripts/lintrunner.sh
-      - name: Check reproducer exists for AI-generated PR
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'ai_generated') }}
-        env:
-          GH_TOKEN: ${{ secrets.MERGE_TOKEN }}
-        run: |
-          cd ./torch-xpu-ops
-          FAIL_MSG=""
-          # Check if reproducer files exist
-          if ! ls test/repro/test_*.py 1>/dev/null 2>&1; then
-            FAIL_MSG="No reproducer test found. AI-generated PRs must include at least one reproducer in \`test/repro/test_*.py\`."
-          else
-            # Validate pytest format: must contain test functions or test classes
-            VALID=false
-            for f in test/repro/test_*.py; do
-              if grep -qE '^[[:space:]]*(def test_|class Test)' "$f"; then
-                VALID=true
-              else
-                FAIL_MSG="Reproducer \`$f\` is not in pytest format. It must contain pytest-style test functions (\`def test_...\`) or test classes (\`class Test...\`)."
-                break
-              fi
-            done
-            if [ "$VALID" = true ] && [ -z "$FAIL_MSG" ]; then
-              echo "All reproducer tests are valid pytest format:"
-              ls test/repro/test_*.py
-            fi
-          fi
-          if [ -n "$FAIL_MSG" ]; then
-            PR_AUTHOR="${{ github.event.pull_request.user.login }}"
-            printf -v COMMENT_BODY '%s\n' \
-              "@${PR_AUTHOR} ${FAIL_MSG}" \
-              "" \
-              "Please ensure your reproducer follows pytest conventions:" \
-              "- File name: \`test/repro/test_<description>.py\`" \
-              "- Contains \`def test_...()\` functions or \`class Test...\` classes" \
-              "- Runnable via \`pytest test/repro/\`"
-            gh pr comment ${{ github.event.pull_request.number }} --body "${COMMENT_BODY}"
-            echo "::error::${FAIL_MSG}"
-            exit 1
-          fi
+    secrets:
+      github-token: ${{ secrets.MERGE_TOKEN }}
+    uses: ./.github/workflows/_lint.yml
+    with:
+      runner: ubuntu-24.04
+      python-version: '3.10'
+      check-reproducer: ${{ contains(github.event.pull_request.labels.*.name, 'ai_generated') }}
 
   # Resolve test matrix from labels / path changes
   preci-matrix:


### PR DESCRIPTION
## Summary

First PR in the CI/CD refactor series. Refactors **code check** (lint, clang-format, optional clang-tidy, AI-generated PR reproducer validation) into reusable, composable pieces.

## Changes

| File | Change |
|---|---|
| `.github/workflows/_lint.yml` | **New** reusable workflow with parallel jobs: `lint`, `clang-format`, opt-in `clang-tidy`, opt-in `reproducer`. |
| `.github/actions/code-check/` | **New** composite action wrapping `lintrunner.sh`. Configurable `scope` (`lint` / `clang-format` / `clang-tidy` / `custom`), `python-version`, `working-directory`. Auto-uploads `lint.json` artifact. |
| `.github/actions/check-reproducer/` | **New** composite action extracting the AI-generated PR reproducer validation. Outputs `ok` / `reason`, posts a PR comment when a token is provided. |
| `.github/scripts/lintrunner.sh` | Strict mode (`set -euo pipefail`), env-driven config (`LINT_PYTHON_VERSION`, `LINT_VENV_DIR`, `LINT_CACHE_DIR`), structured `[lint]` logs, GitHub step-summary with error/warning counts and a top-findings table. |
| `.github/workflows/pull.yml` | `preci-lint-check` reduced from ~70 lines to a 12-line `uses: ./.github/workflows/_lint.yml` call. Reproducer check is now toggled by the `ai_generated` label via the same workflow. |

## Improvements

- **Reusability**: `_lint.yml` can be called from `nightly_ondemand.yml`, `acceptance`, etc.
- **Visibility**: Each check is a separate job → distinct pass/fail signal in the GitHub UI.
- **Reporting**: Lint findings now appear in the job step summary with a counts table and top-50 findings table; `lint.json` uploaded as artifact for downstream tooling.
- **Error handling**: Strict-mode shell, explicit failure messages, structured GitHub annotations.
- **Configurability**: Python version, scope, working directory, artifact name all parameterized.

## Defaults

- Python: **3.10**
- Action versions: `actions/checkout@v6`, `actions/upload-artifact@v7` (matching repo convention).

## Roadmap

This is **PR 1 of N** in the CI/CD refactor. Subsequent PRs will refactor: build, unit tests, dynamo benchmark, distributed, microbench, accelerate, transformers, and unified reporting (with new-failure highlighting).