### PR TITLE
Refactor build pipeline: extract composite actions

### DIFF
--- a/.github/actions/build-domain-lib/action.yml
+++ b/.github/actions/build-domain-lib/action.yml
@@ -1,0 +1,94 @@
+name: build-domain-lib
+description: |
+  Build a PyTorch domain library (TorchVision, TorchAudio, ...) at the commit
+  pinned by `<pytorch>/.github/ci_commit_pins/<pin-file>`, install the
+  resulting wheel, and stage it under `build-dir` for artifact upload.
+
+inputs:
+  name:
+    description: Wheel name prefix (e.g. `torchvision`, `torchaudio`).
+    required: true
+  repo-url:
+    description: Git URL to clone.
+    required: true
+  pin-file:
+    description: |
+      File under `<pytorch-src>/.github/ci_commit_pins/` holding the commit pin.
+      When the file is missing, falls back to `main`.
+    required: true
+  pytorch-src:
+    description: Path to the PyTorch source checkout (used to read the pin).
+    required: true
+  build-dir:
+    description: Destination directory for the produced wheel and build log.
+    required: true
+  gcc-version:
+    description: gcc-toolset version to source on RH-based images.
+    required: false
+    default: '13'
+  os-packages:
+    description: Space-separated list of OS packages to dnf-install before building.
+    required: false
+    default: ''
+  branch:
+    description: Branch to clone before checking out the pinned commit.
+    required: false
+    default: main
+
+runs:
+  using: composite
+  steps:
+    - name: Build ${{ inputs.name }}
+      shell: bash
+      env:
+        NAME: ${{ inputs.name }}
+        REPO_URL: ${{ inputs.repo-url }}
+        PIN_FILE: ${{ inputs.pin-file }}
+        PYTORCH_SRC: ${{ inputs.pytorch-src }}
+        BUILD_DIR: ${{ inputs.build-dir }}
+        GCC_VERSION: ${{ inputs.gcc-version }}
+        OS_PACKAGES: ${{ inputs.os-packages }}
+        BRANCH: ${{ inputs.branch }}
+      run: |
+        set -euo pipefail
+        # shellcheck disable=SC1091
+        if [[ -f "/opt/rh/gcc-toolset-${GCC_VERSION}/enable" ]]; then
+          source "/opt/rh/gcc-toolset-${GCC_VERSION}/enable"
+        fi
+
+        if [[ ! -d "${PYTORCH_SRC}" ]]; then
+          echo "::error title=Missing PyTorch source::Expected at ${PYTORCH_SRC}"
+          exit 1
+        fi
+
+        if [[ -n "${OS_PACKAGES}" ]] && command -v dnf &>/dev/null; then
+          # shellcheck disable=SC2086
+          dnf install -y ${OS_PACKAGES}
+        fi
+
+        cd "${PYTORCH_SRC}"
+        commit="$(cat ".github/ci_commit_pins/${PIN_FILE}" 2>/dev/null || echo main)"
+        echo "${NAME} pin: ${commit}"
+
+        src_dir="${NAME}-xpu"
+        rm -rf "${src_dir}"
+        git clone --single-branch -b "${BRANCH}" "${REPO_URL}" "${src_dir}"
+        ( cd "${src_dir}" && git checkout "${commit}" )
+
+        log="${BUILD_DIR}/build_${NAME}_${commit}.log"
+        ( cd "${src_dir}" && python setup.py bdist_wheel ) 2>&1 | tee "${log}"
+
+        wheel=$(find "${src_dir}/dist/" -name "${NAME}-*.whl" -type f | head -1)
+        if [[ -z "${wheel}" ]]; then
+          echo "::error title=${NAME} build failed::No wheel produced"
+          exit 1
+        fi
+        pip install "${wheel}"
+        cp "${wheel}" "${BUILD_DIR}/"
+
+        {
+          echo "## ${NAME} build"
+          echo
+          echo "- commit: \`${commit}\`"
+          echo "- wheel: \`$(basename "${wheel}")\`"
+        } >> "${GITHUB_STEP_SUMMARY:-/dev/null}" || true

--- a/.github/actions/build-pytorch-xpu/action.yml
+++ b/.github/actions/build-pytorch-xpu/action.yml
@@ -1,0 +1,80 @@
+name: build-pytorch-xpu
+description: |
+  Build PyTorch with XPU support via `.github/scripts/build.sh`, capture a
+  timestamped build log, and verify exactly one `torch-*.whl` was produced.
+
+inputs:
+  build-dir:
+    description: Directory passed to `build.sh --WORKSPACE` and where the wheel lands.
+    required: true
+  pytorch:
+    description: PyTorch spec (`commit`, `branch`, `repo@commit`).
+    required: true
+  torch-xpu-ops:
+    description: torch-xpu-ops spec or `pinned`.
+    required: false
+    default: ''
+  component:
+    description: Component to override (e.g. `onednn`, `sycltla`, `oneapi`).
+    required: false
+    default: ''
+  component-version:
+    description: Component spec/URL.
+    required: false
+    default: ''
+  gcc-version:
+    description: gcc-toolset version to source on RH-based images.
+    required: false
+    default: '13'
+  torch-xpu-ops-src:
+    description: Path to the torch-xpu-ops checkout (where `build.sh` lives).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Build PyTorch XPU
+      shell: bash
+      env:
+        BUILD_DIR: ${{ inputs.build-dir }}
+        TORCH_XPU_OPS_SRC: ${{ inputs.torch-xpu-ops-src }}
+        PYTORCH_SPEC: ${{ inputs.pytorch }}
+        TORCH_XPU_OPS_SPEC: ${{ inputs.torch-xpu-ops }}
+        COMPONENT: ${{ inputs.component }}
+        COMPONENT_VERSION: ${{ inputs.component-version }}
+        GCC_VERSION: ${{ inputs.gcc-version }}
+      run: |
+        set -euo pipefail
+        # shellcheck disable=SC1091
+        if [[ -f "/opt/rh/gcc-toolset-${GCC_VERSION}/enable" ]]; then
+          source "/opt/rh/gcc-toolset-${GCC_VERSION}/enable"
+        fi
+        # shellcheck disable=SC1091
+        source "${TORCH_XPU_OPS_SRC}/.github/scripts/env.sh" || true
+
+        mkdir -p "${BUILD_DIR}"
+        log="${BUILD_DIR}/build_pytorch_$(date +%Y%m%d%H%M%S).log"
+
+        "${TORCH_XPU_OPS_SRC}/.github/scripts/build.sh" \
+            --WORKSPACE="${BUILD_DIR}/" \
+            --PYTORCH="${PYTORCH_SPEC}" \
+            --TORCH_XPU_OPS="${TORCH_XPU_OPS_SPEC}" \
+            --COMPONENT="${COMPONENT}" \
+            --COMPONENT_COMMIT="${COMPONENT_VERSION}" \
+          2>&1 | tee "${log}"
+
+        wheel_count=$(find "${BUILD_DIR}/" -maxdepth 1 -name "torch-*.whl" -type f | wc -l)
+        if [[ "${wheel_count}" -ne 1 ]]; then
+          echo "::error title=PyTorch wheel build failed::Expected 1 torch wheel, found ${wheel_count}"
+          ls -la "${BUILD_DIR}/" || true
+          exit 1
+        fi
+
+        wheel=$(find "${BUILD_DIR}/" -maxdepth 1 -name "torch-*.whl" -type f -printf '%f\n' | head -1)
+        {
+          echo "## PyTorch build"
+          echo
+          echo "- spec: \`${PYTORCH_SPEC}\`"
+          echo "- torch-xpu-ops: \`${TORCH_XPU_OPS_SPEC}\`"
+          echo "- wheel: \`${wheel}\`"
+        } >> "${GITHUB_STEP_SUMMARY:-/dev/null}" || true

--- a/.github/actions/build-triton-xpu/action.yml
+++ b/.github/actions/build-triton-xpu/action.yml
@@ -1,0 +1,132 @@
+name: build-triton-xpu
+description: |
+  Provide a `triton-xpu` wheel: first try to download a pre-built nightly wheel
+  matching the requested commit short hash; otherwise build from source via
+  `pytorch/.github/scripts/build_triton_wheel.py`. The resulting wheel is
+  copied to `build-dir` and pip-installed.
+
+inputs:
+  pytorch-src:
+    description: Path to PyTorch source (used for `build_triton_wheel.py` and the default commit pin).
+    required: true
+  build-dir:
+    description: Destination directory for the wheel and build log.
+    required: true
+  triton-spec:
+    description: |
+      `repo@commit` or just `commit`. When empty, the default repo is used and
+      the commit is read from `pytorch-src/.ci/docker/ci_commit_pins/triton-xpu.txt`.
+    required: false
+    default: ''
+  default-repo:
+    description: Default Triton repository (`owner/repo`) when no `@` is given.
+    required: false
+    default: intel/intel-xpu-backend-for-triton
+  index-url:
+    description: pip index URL for pre-built nightly wheels.
+    required: false
+    default: https://download.pytorch.org/whl/nightly/xpu
+  gcc-version:
+    description: gcc-toolset version to source on RH-based images.
+    required: false
+    default: '13'
+
+runs:
+  using: composite
+  steps:
+    - name: Build or fetch Triton (XPU)
+      shell: bash
+      env:
+        PYTORCH_SRC: ${{ inputs.pytorch-src }}
+        BUILD_DIR: ${{ inputs.build-dir }}
+        TRITON_SPEC: ${{ inputs.triton-spec }}
+        DEFAULT_REPO: ${{ inputs.default-repo }}
+        INDEX_URL: ${{ inputs.index-url }}
+        GCC_VERSION: ${{ inputs.gcc-version }}
+      run: |
+        set -euo pipefail
+        # shellcheck disable=SC1091
+        if [[ -f "/opt/rh/gcc-toolset-${GCC_VERSION}/enable" ]]; then
+          source "/opt/rh/gcc-toolset-${GCC_VERSION}/enable"
+        fi
+
+        # Resolve repo + commit
+        if [[ -n "${TRITON_SPEC}" ]]; then
+          if [[ "${TRITON_SPEC}" == *"@"* ]]; then
+            repo="${TRITON_SPEC%%@*}"
+            commit="${TRITON_SPEC##*@}"
+          else
+            repo="${DEFAULT_REPO}"
+            commit="${TRITON_SPEC}"
+          fi
+        else
+          repo="${DEFAULT_REPO}"
+          commit="$(cat "${PYTORCH_SRC}/.ci/docker/ci_commit_pins/triton-xpu.txt" 2>/dev/null || echo main)"
+        fi
+        short="${commit:0:7}"
+        echo "Triton: ${repo} @ ${commit} (short ${short})"
+
+        # 1) Try a pre-built nightly wheel matching the short commit.
+        wheel=""
+        versions=$(
+          pip index versions --index-url "${INDEX_URL}" --pre triton-xpu 2>/dev/null \
+            | grep -oE 'triton-xpu==[0-9a-zA-Z.-]+' || true
+        )
+        match=""
+        while IFS= read -r v; do
+          [[ -z "${v}" ]] && continue
+          if [[ "${v}" == *"${short}"* ]]; then
+            match="${v#*==}"
+            break
+          fi
+        done <<< "${versions}"
+
+        if [[ -n "${match}" ]]; then
+          echo "Using pre-built triton-xpu==${match}"
+          pip download --no-deps --index-url "${INDEX_URL}" --pre \
+            "triton-xpu==${match}" --dest "${BUILD_DIR}/"
+          wheel=$(find "${BUILD_DIR}" -maxdepth 1 -name "triton*.whl" -type f | head -1)
+        else
+          echo "No matching pre-built wheel; building from source"
+          if command -v dnf &>/dev/null; then
+            dnf install -y zlib-devel || true
+          fi
+          pip install --quiet cmake ninja pybind11
+
+          version=$(
+            curl -sSL "https://raw.githubusercontent.com/${repo}/${commit}/python/triton/__init__.py" 2>/dev/null \
+              | grep '__version__' | head -n1 | awk -F"'" '{print $2}' || echo unknown
+          )
+          echo "Triton version: ${version}"
+
+          cd "${PYTORCH_SRC}"
+          # Repoint the build helper at the requested fork.
+          sed -i "s+intel/intel-xpu-backend-for-triton+${repo}+g" .github/scripts/build_triton_wheel.py
+
+          log="${BUILD_DIR}/build_triton_${commit}.log"
+          python .github/scripts/build_triton_wheel.py \
+            --device xpu \
+            --commit-hash "${commit}" \
+            --triton-version "${version}" \
+            2>&1 | tee "${log}"
+
+          wheel=$(find . -name "triton_xpu-*.whl" -type f | head -1)
+          if [[ -z "${wheel}" ]]; then
+            echo "::error title=Triton build failed::No wheel produced"
+            exit 1
+          fi
+          cp "${wheel}" "${BUILD_DIR}/"
+          wheel="${BUILD_DIR}/$(basename "${wheel}")"
+        fi
+
+        if [[ -n "${wheel}" && -f "${wheel}" ]]; then
+          pip install "${wheel}"
+        fi
+
+        {
+          echo "## Triton build"
+          echo
+          echo "- repo: \`${repo}\`"
+          echo "- commit: \`${commit}\`"
+          [[ -n "${wheel}" ]] && echo "- wheel: \`$(basename "${wheel}")\`"
+        } >> "${GITHUB_STEP_SUMMARY:-/dev/null}" || true

--- a/.github/actions/setup-build-python/action.yml
+++ b/.github/actions/setup-build-python/action.yml
@@ -1,0 +1,61 @@
+name: setup-build-python
+description: |
+  Locate a manylinux2_28 `cp<ver>-cp<ver>` Python interpreter under `/opt/python`
+  and create a fresh virtualenv at `${VENV_DIR}` with up-to-date build tooling.
+
+inputs:
+  python-version:
+    description: Python version, e.g. `3.10`.
+    required: true
+  venv-dir:
+    description: Where to create the build venv.
+    required: false
+    default: /tmp/xpu-tool/myvenv
+  setuptools-spec:
+    description: setuptools pin (passed verbatim to `pip install`).
+    required: false
+    default: 'setuptools<=81'
+
+outputs:
+  python:
+    description: Absolute path to the venv's Python interpreter.
+    value: ${{ steps.setup.outputs.python }}
+
+runs:
+  using: composite
+  steps:
+    - name: Create build venv
+      id: setup
+      shell: bash
+      env:
+        PY_VER: ${{ inputs.python-version }}
+        VENV_DIR: ${{ inputs.venv-dir }}
+        SETUPTOOLS_SPEC: ${{ inputs.setuptools-spec }}
+      run: |
+        set -euo pipefail
+        rm -rf "${VENV_DIR}"
+
+        py_tag="cp${PY_VER/./}-cp${PY_VER/./}"
+        py_bin=""
+        for dir in /opt/python/${py_tag}*; do
+          if [[ -x "${dir}/bin/python" ]]; then
+            py_bin="${dir}/bin/python"
+            break
+          fi
+        done
+        if [[ -z "${py_bin}" ]]; then
+          echo "::error title=Python not found::Python ${PY_VER} (tag ${py_tag}) not found under /opt/python"
+          ls -1 /opt/python || true
+          exit 1
+        fi
+
+        echo "Found interpreter: ${py_bin}"
+        "${py_bin}" -m venv "${VENV_DIR}"
+
+        # shellcheck disable=SC1090
+        source "${VENV_DIR}/bin/activate"
+        pip install --quiet -U pip wheel "${SETUPTOOLS_SPEC}"
+
+        echo "python=${VENV_DIR}/bin/python" >> "${GITHUB_OUTPUT}"
+        echo "${VENV_DIR}/bin" >> "${GITHUB_PATH}"
+        python --version

--- a/.github/actions/setup-oneapi/action.yml
+++ b/.github/actions/setup-oneapi/action.yml
@@ -1,0 +1,62 @@
+name: setup-oneapi
+description: |
+  Install Intel oneAPI DLE from a remote installer URL and export
+  `XPU_ONEAPI_PATH` for downstream steps.
+
+inputs:
+  installer-url:
+    description: |
+      URL of the oneAPI offline installer (`*.sh`). When empty, the action
+      is a no-op and existing `XPU_ONEAPI_PATH` (if any) is preserved.
+    required: false
+    default: ''
+  install-dir:
+    description: Target installation directory.
+    required: false
+    default: /opt/intel/oneapi
+  remove-existing:
+    description: Whether to remove a pre-existing oneAPI tree before installing.
+    required: false
+    default: 'true'
+
+outputs:
+  path:
+    description: Absolute path to the oneAPI install (`XPU_ONEAPI_PATH`).
+    value: ${{ steps.install.outputs.path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install oneAPI
+      id: install
+      shell: bash
+      env:
+        URL: ${{ inputs.installer-url }}
+        INSTALL_DIR: ${{ inputs.install-dir }}
+        REMOVE_EXISTING: ${{ inputs.remove-existing }}
+      run: |
+        set -euo pipefail
+        if [[ -z "${URL}" ]]; then
+          echo "No installer-url provided; skipping oneAPI install."
+          echo "path=${XPU_ONEAPI_PATH:-}" >> "${GITHUB_OUTPUT}"
+          exit 0
+        fi
+
+        if [[ "${REMOVE_EXISTING}" == "true" ]]; then
+          echo "Removing existing oneAPI installations..."
+          rm -rf ~/intel ~/.intel "${HOME}/intel" /opt/intel || true
+        fi
+
+        echo "Downloading oneAPI installer from ${URL}"
+        installer="$(mktemp --suffix=.sh)"
+        trap 'rm -f "${installer}"' EXIT
+        wget -q -O "${installer}" "${URL}"
+
+        echo "Removing any prior install in ${INSTALL_DIR}"
+        bash "${installer}" -a -s --eula accept --action remove || true
+
+        echo "Installing oneAPI to ${INSTALL_DIR}"
+        bash "${installer}" -a -s --eula accept --action install --install-dir "${INSTALL_DIR}"
+
+        echo "XPU_ONEAPI_PATH=${INSTALL_DIR}" >> "${GITHUB_ENV}"
+        echo "path=${INSTALL_DIR}" >> "${GITHUB_OUTPUT}"

--- a/.github/actions/verify-pytorch-build/action.yml
+++ b/.github/actions/verify-pytorch-build/action.yml
@@ -1,0 +1,68 @@
+name: verify-pytorch-build
+description: |
+  Run `import` smoke tests for torch / triton / torchvision / torchaudio,
+  list installed XPU-relevant packages, and emit a structured GitHub step
+  summary. Fails the step on any import error.
+
+inputs:
+  build-dir:
+    description: Directory where wheels were staged (listed in the summary).
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Verify PyTorch + Triton + domain libraries
+      shell: bash
+      env:
+        BUILD_DIR: ${{ inputs.build-dir }}
+      run: |
+        set -uo pipefail
+        rc=0
+
+        check() {
+          local name="$1"; shift
+          local expr="$1"
+          local out
+          if out=$(python -c "${expr}" 2>&1); then
+            printf '  %-12s OK   %s\n' "${name}" "${out}"
+            echo "| ${name} | ✅ | \`${out}\` |" >> /tmp/_verify_rows
+          else
+            printf '  %-12s FAIL %s\n' "${name}" "${out}" >&2
+            echo "| ${name} | ❌ | \`${out}\` |" >> /tmp/_verify_rows
+            rc=1
+          fi
+        }
+
+        : > /tmp/_verify_rows
+
+        check torch       "import torch; print(torch.__version__)"
+        check 'torch.xpu'  "import torch; print('devices=' + str(torch.xpu.device_count()))"
+        check triton      "import triton; print(triton.__version__)"
+        check torchvision "import torchvision; print(torchvision.__version__)"
+        check torchaudio  "import torchaudio; print(torchaudio.__version__)"
+
+        echo "Installed packages (filtered):"
+        pip list 2>/dev/null | grep -iE 'torch|triton|intel|xpu' || true
+
+        if [[ -n "${BUILD_DIR}" && -d "${BUILD_DIR}" ]]; then
+          echo "Wheels in ${BUILD_DIR}:"
+          find "${BUILD_DIR}" -maxdepth 1 -name '*.whl' -type f -exec basename {} \; | sort
+        fi
+
+        {
+          echo "## Build verification"
+          echo
+          echo "| Component | Status | Detail |"
+          echo "|-----------|--------|--------|"
+          cat /tmp/_verify_rows
+          if [[ -n "${BUILD_DIR}" && -d "${BUILD_DIR}" ]]; then
+            echo
+            echo "### Wheels"
+            echo
+            find "${BUILD_DIR}" -maxdepth 1 -name '*.whl' -type f -printf '- `%f`\n' | sort
+          fi
+        } >> "${GITHUB_STEP_SUMMARY:-/dev/null}" || true
+
+        exit "${rc}"

--- a/.github/workflows/_linux_build.yml
+++ b/.github/workflows/_linux_build.yml
@@ -52,7 +52,7 @@ env:
   DOCKER_REGISTRY_AUTH_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
   WORKSPACE: ${{ github.workspace }}
   PATH: /tmp/xpu-tool/myvenv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-  GCC_VERSION: 13
+  GCC_VERSION: '13'
   BUILD_DIR: ${{ github.workspace }}/${{ inputs.category }}
   PYTORCH_SRC: ${{ github.workspace }}/${{ inputs.category }}/pytorch
   TORCH_XPU_OPS_SRC: ${{ github.workspace }}/${{ inputs.category }}/torch-xpu-ops
@@ -112,7 +112,7 @@ jobs:
       - name: Prepare workspace
         run: |
           find . -maxdepth 1 ! -name '.' ! -name '..' -exec rm -rf {} + 2>/dev/null || true
-          mkdir -p "${{ env.BUILD_DIR }}"
+          mkdir -p "${BUILD_DIR}"
 
       - name: Install GitHub CLI
         run: |
@@ -121,161 +121,71 @@ jobs:
           dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
           dnf install -y gh --repo gh-cli
 
-      - name: Setup Python ${{ inputs.python }}
-        run: |
-          rm -rf /tmp/xpu-tool/myvenv
-          py_ver="${{ inputs.python }}"
-          py_tag="cp${py_ver/./}-cp${py_ver/./}"
-          py_bin=""
-          for dir in /opt/python/${py_tag}*; do
-            [[ -x "${dir}/bin/python" ]] && { py_bin="${dir}/bin/python"; break; }
-          done
-          [[ -z "${py_bin}" ]] && { echo "::error::Python ${py_ver} not found"; exit 1; }
-          "${py_bin}" -m venv /tmp/xpu-tool/myvenv
-          source /tmp/xpu-tool/myvenv/bin/activate
-          pip install -U pip wheel "setuptools<=81"
-
       - name: Checkout torch-xpu-ops
         uses: actions/checkout@v6
         with:
           path: ${{ env.TORCH_XPU_OPS_SRC }}
           fetch-depth: 1
 
+      - name: Setup Python ${{ inputs.python }}
+        uses: ./.github/actions/setup-build-python
+        with:
+          python-version: ${{ inputs.python }}
+
       - name: Setup oneAPI DLE
         if: inputs.component == 'oneapi'
-        run: |
-          rm -rf ~/intel ~/.intel ${HOME}/intel /opt/intel
-          wget -q -O oneapi.sh "${{ inputs.component_version }}"
-          bash oneapi.sh -a -s --eula accept --action remove || true
-          bash oneapi.sh -a -s --eula accept --action install --install-dir /opt/intel/oneapi
-          echo "XPU_ONEAPI_PATH=/opt/intel/oneapi" >> "${GITHUB_ENV}"
+        uses: ./.github/actions/setup-oneapi
+        with:
+          installer-url: ${{ inputs.component_version }}
 
       # ── Core build ────────────────────────────────────────────────────────
       - name: Build PyTorch XPU
-        run: |
-          source /opt/rh/gcc-toolset-${GCC_VERSION}/enable
-          source "${TORCH_XPU_OPS_SRC}/.github/scripts/env.sh" || true
-
-          "${TORCH_XPU_OPS_SRC}/.github/scripts/build.sh" \
-            --WORKSPACE="${BUILD_DIR}/" \
-            --PYTORCH="${{ inputs.pytorch }}" \
-            --TORCH_XPU_OPS="${{ inputs.torch_xpu_ops }}" \
-            --COMPONENT="${{ inputs.component }}" \
-            --COMPONENT_COMMIT="${{ inputs.component_version }}" \
-            2>&1 | tee "${BUILD_DIR}/build_pytorch_$(date +%Y%m%d%H%M%S).log"
-
-          WHEEL_COUNT=$(find "${BUILD_DIR}/" -maxdepth 1 -name "torch-*.whl" -type f | wc -l)
-          if [[ "${WHEEL_COUNT}" -ne 1 ]]; then
-            echo "::error::Expected 1 torch wheel, found ${WHEEL_COUNT}"
-            exit 1
-          fi
+        uses: ./.github/actions/build-pytorch-xpu
+        with:
+          build-dir: ${{ env.BUILD_DIR }}
+          pytorch: ${{ inputs.pytorch }}
+          torch-xpu-ops: ${{ inputs.torch_xpu_ops }}
+          component: ${{ inputs.component }}
+          component-version: ${{ inputs.component_version }}
+          gcc-version: ${{ env.GCC_VERSION }}
+          torch-xpu-ops-src: ${{ env.TORCH_XPU_OPS_SRC }}
 
       # ── Domain libraries ──────────────────────────────────────────────────
       - name: Build TorchVision
-        run: |
-          source /opt/rh/gcc-toolset-${GCC_VERSION}/enable
-          [[ -d "${PYTORCH_SRC}" ]] || { echo "::error::PyTorch source not found"; exit 1; }
-
-          cd "${PYTORCH_SRC}"
-          dnf install -y libpng-devel libjpeg-devel
-
-          COMMIT="$(cat .github/ci_commit_pins/vision.txt 2>/dev/null || echo main)"
-          rm -rf vision-xpu
-          git clone --single-branch -b main https://github.com/pytorch/vision.git vision-xpu
-          cd vision-xpu && git checkout "${COMMIT}"
-
-          python setup.py bdist_wheel 2>&1 | tee "${BUILD_DIR}/build_vision_${COMMIT}.log"
-
-          WHEEL=$(find dist/ -name "torchvision-*.whl" -type f)
-          [[ -z "${WHEEL}" ]] && { echo "::error::TorchVision build failed"; exit 1; }
-          pip install "${WHEEL}" && cp "${WHEEL}" "${BUILD_DIR}/"
+        uses: ./.github/actions/build-domain-lib
+        with:
+          name: torchvision
+          repo-url: https://github.com/pytorch/vision.git
+          pin-file: vision.txt
+          pytorch-src: ${{ env.PYTORCH_SRC }}
+          build-dir: ${{ env.BUILD_DIR }}
+          gcc-version: ${{ env.GCC_VERSION }}
+          os-packages: libpng-devel libjpeg-devel
 
       - name: Build TorchAudio
-        run: |
-          source /opt/rh/gcc-toolset-${GCC_VERSION}/enable
-          [[ -d "${PYTORCH_SRC}" ]] || { echo "::error::PyTorch source not found"; exit 1; }
-
-          cd "${PYTORCH_SRC}"
-          COMMIT="$(cat .github/ci_commit_pins/audio.txt 2>/dev/null || echo main)"
-          rm -rf audio-xpu
-          git clone --single-branch -b main https://github.com/pytorch/audio.git audio-xpu
-          cd audio-xpu && git checkout "${COMMIT}"
-
-          python setup.py bdist_wheel 2>&1 | tee "${BUILD_DIR}/build_audio_${COMMIT}.log"
-
-          WHEEL=$(find dist/ -name "torchaudio-*.whl" -type f)
-          [[ -z "${WHEEL}" ]] && { echo "::error::TorchAudio build failed"; exit 1; }
-          pip install "${WHEEL}" && cp "${WHEEL}" "${BUILD_DIR}/"
+        uses: ./.github/actions/build-domain-lib
+        with:
+          name: torchaudio
+          repo-url: https://github.com/pytorch/audio.git
+          pin-file: audio.txt
+          pytorch-src: ${{ env.PYTORCH_SRC }}
+          build-dir: ${{ env.BUILD_DIR }}
+          gcc-version: ${{ env.GCC_VERSION }}
 
       # ── Triton ────────────────────────────────────────────────────────────
-      - name: Build or download Triton
-        run: |
-          source /opt/rh/gcc-toolset-${GCC_VERSION}/enable
-
-          # Resolve repo + commit
-          TRITON_REPO="intel/intel-xpu-backend-for-triton"
-          if [[ "${{ inputs.component }}" == "triton" && -n "${{ inputs.component_version }}" ]]; then
-            spec="${{ inputs.component_version }}"
-            if [[ "${spec}" == *"@"* ]]; then
-              TRITON_REPO="${spec%%@*}"
-              TRITON_COMMIT="${spec##*@}"
-            else
-              TRITON_COMMIT="${spec}"
-            fi
-          else
-            TRITON_COMMIT="$(cat "${PYTORCH_SRC}/.ci/docker/ci_commit_pins/triton-xpu.txt" 2>/dev/null || echo main)"
-          fi
-          echo "Triton: ${TRITON_REPO}@${TRITON_COMMIT}"
-
-          # Try pre-built nightly wheel
-          SHORT="${TRITON_COMMIT:0:7}"
-          VERSIONS=$(pip index versions --index-url https://download.pytorch.org/whl/nightly/xpu \
-            --pre triton-xpu 2>/dev/null | grep -o 'triton-xpu==[0-9a-zA-Z.-]*' || true)
-          DL_VER=""
-          while IFS= read -r v; do
-            [[ "${v}" == *"${SHORT}"* ]] && { DL_VER="${v#*==}"; break; }
-          done <<< "${VERSIONS}"
-
-          if [[ -n "${DL_VER}" ]]; then
-            pip download --no-deps --index-url https://download.pytorch.org/whl/nightly/xpu \
-              --pre "triton-xpu==${DL_VER}" --dest "${BUILD_DIR}/"
-            TRITON_WHEEL=$(find "${BUILD_DIR}" -name "triton*.whl" -type f | head -1)
-          else
-            echo "No pre-built wheel; building from source..."
-            dnf install -y zlib-devel
-            pip install cmake ninja pybind11
-
-            TRITON_VERSION=$(
-              curl -sSL "https://raw.githubusercontent.com/${TRITON_REPO}/${TRITON_COMMIT}/python/triton/__init__.py" 2>/dev/null \
-                | grep '__version__' | head -n1 | awk -F"'" '{print $2}' || echo "unknown"
-            )
-
-            cd "${PYTORCH_SRC}"
-            sed -i "s+intel/intel-xpu-backend-for-triton+${TRITON_REPO}+g" .github/scripts/build_triton_wheel.py
-            python .github/scripts/build_triton_wheel.py \
-              --device xpu \
-              --commit-hash "${TRITON_COMMIT}" \
-              --triton-version "${TRITON_VERSION}" \
-              2>&1 | tee "${BUILD_DIR}/build_triton_${TRITON_COMMIT}.log"
-
-            TRITON_WHEEL=$(find . -name "triton_xpu-*.whl" -type f | head -1)
-            [[ -z "${TRITON_WHEEL}" ]] && { echo "::error::Triton build failed"; exit 1; }
-            cp "${TRITON_WHEEL}" "${BUILD_DIR}/"
-          fi
-
-          [[ -f "${TRITON_WHEEL}" ]] && pip install "${TRITON_WHEEL}"
+      - name: Build or fetch Triton XPU
+        uses: ./.github/actions/build-triton-xpu
+        with:
+          pytorch-src: ${{ env.PYTORCH_SRC }}
+          build-dir: ${{ env.BUILD_DIR }}
+          triton-spec: ${{ inputs.component == 'triton' && inputs.component_version || '' }}
+          gcc-version: ${{ env.GCC_VERSION }}
 
       # ── Verify ────────────────────────────────────────────────────────────
       - name: Verify build
-        run: |
-          source /tmp/xpu-tool/myvenv/bin/activate
-          python -c "import torch; print('PyTorch:', torch.__version__)"
-          python -c "import torch; print('XPU devices:', torch.xpu.device_count())"
-          python -c "import triton; print('Triton:', triton.__version__)"
-          python -c "import torchvision; print('TorchVision:', torchvision.__version__)"
-          python -c "import torchaudio; print('TorchAudio:', torchaudio.__version__)"
-          pip list | grep -iE 'torch|triton|intel|xpu'
-          find "${BUILD_DIR}" -name "*.whl" -type f -exec basename {} \;
+        uses: ./.github/actions/verify-pytorch-build
+        with:
+          build-dir: ${{ env.BUILD_DIR }}
 
       # ── Upload ────────────────────────────────────────────────────────────
       - name: Upload build artifacts


### PR DESCRIPTION
## Summary

Second PR in the CI/CD refactor series. Extracts the monolithic build steps in `_linux_build.yml` into six reusable composite actions, reduces the workflow body from ~190 inline-bash lines to ~70 declarative lines, and adds structured GitHub step-summary output for each build stage.

> **Stacked on:** [#11 — Refactor code check](https://github.com/mengfei25/torch-xpu-ops/pull/11). Review/merge that first.

## New composite actions

| Action | Purpose |
|---|---|
| `setup-build-python` | Find a `cp<ver>-cp<ver>` interpreter under `/opt/python` and create the build venv. |
| `setup-oneapi` | Install Intel oneAPI DLE from a remote installer URL; export `XPU_ONEAPI_PATH`. |
| `build-pytorch-xpu` | Wrap `build.sh`, capture timestamped log, verify exactly one `torch-*.whl`. |
| `build-domain-lib` | Parameterized builder for TorchVision / TorchAudio (repo, pin file, OS deps). |
| `build-triton-xpu` | Try pre-built nightly wheel matching short commit; fall back to source build via `build_triton_wheel.py`. |
| `verify-pytorch-build` | Structured `import` smoke tests for torch / triton / domain libs → step summary table. |

## `_linux_build.yml` diff

- 'Setup Python' block (~15 lines) → `setup-build-python`
- 'Setup oneAPI DLE' block (~10 lines) → `setup-oneapi`
- 'Build PyTorch XPU' block (~20 lines) → `build-pytorch-xpu`
- 'Build TorchVision' / 'Build TorchAudio' (~30 lines each) → `build-domain-lib` (×2)
- 'Build or download Triton' block (~50 lines) → `build-triton-xpu`
- 'Verify build' block (~10 `python -c` calls) → `verify-pytorch-build` (with step-summary table)

Net: 7 files changed, **+543 / −136** (most additions are net-new reusable actions).

## Behavior

- Functional behavior is preserved (same env, same build.sh invocation, same artifact name and contents).
- New: each stage emits a section in the GitHub step summary; verify step shows a status table; failures emit `::error::` annotations with titles.
- Default Python remains 3.10.

## Roadmap

PR 1 of N: code check ✅ (#11)
**PR 2 of N: build (this)**
Next: unit tests, dynamo benchmark, distributed, microbench, accelerate, transformers, unified reporting.