### PR TITLE
Refactor E2E pipeline: data-driven matrix + summarizer

### DIFF
--- a/.ci/config/e2e_matrix.yaml
+++ b/.ci/config/e2e_matrix.yaml
@@ -1,0 +1,68 @@
+# E2E (Inductor dynamo benchmark) test matrix.
+#
+# Schema:
+#   <category>:
+#     <suite>:                # one of: huggingface, timm_models, torchbench, pt2e
+#       dt:        <csv>      # e.g. "float32,bfloat16,float16,amp_bf16,amp_fp16"
+#       mode:      <csv>      # "inference,training"
+#       scenario:  <csv>      # "accuracy,performance"
+#     # for pt2e the keys are dt/scenario only (no mode).
+#
+# Categories:
+#   pr        On every pull request (smallest matrix).
+#   nightly   Weekday cron.
+#   weekly    Saturday cron (largest matrix).
+#   ondemand  workflow_dispatch — caller passes through dt/mode/scenario.
+#   target    Component-comparison (target side).
+#   baseline  Component-comparison (baseline side).
+#
+# `ondemand` does not list dt/mode/scenario: those come from workflow inputs.
+# `target`/`baseline` use a fixed two-pass matrix defined in the workflow.
+
+pr:
+  huggingface:
+    dt: bfloat16,float16
+    mode: training
+    scenario: accuracy,performance
+  timm_models:
+    dt: bfloat16
+    mode: training
+    scenario: accuracy,performance
+  torchbench:
+    dt: bfloat16
+    mode: training
+    scenario: accuracy,performance
+
+nightly:
+  huggingface:
+    dt: float32,bfloat16,float16,amp_bf16,amp_fp16
+    mode: inference,training
+    scenario: accuracy,performance
+  timm_models:
+    dt: float16,bfloat16
+    mode: training
+    scenario: accuracy,performance
+  torchbench:
+    dt: float16,bfloat16
+    mode: training
+    scenario: accuracy,performance
+  pt2e:
+    dt: float32,int8
+    scenario: accuracy,performance
+
+weekly:
+  huggingface:
+    dt: float32,bfloat16,float16,amp_bf16,amp_fp16
+    mode: inference,training
+    scenario: accuracy,performance
+  timm_models:
+    dt: float32,bfloat16,float16,amp_bf16,amp_fp16
+    mode: inference,training
+    scenario: accuracy,performance
+  torchbench:
+    dt: float32,bfloat16,float16,amp_bf16,amp_fp16
+    mode: inference,training
+    scenario: accuracy,performance
+  pt2e:
+    dt: float32,int8
+    scenario: accuracy,performance

--- a/.github/actions/resolve-e2e-matrix/action.yml
+++ b/.github/actions/resolve-e2e-matrix/action.yml
@@ -1,0 +1,118 @@
+name: resolve-e2e-matrix
+description: |
+  Resolve the (dt, mode, scenario) matrix for an E2E suite from
+  `.ci/config/e2e_matrix.yaml`. Returns empty outputs when the suite is not
+  configured for the given category — callers should skip the suite in that
+  case.
+
+  For category `ondemand`, all three values come from inputs (`override-*`).
+  For `target` / `baseline`, the workflow drives the matrix directly.
+
+inputs:
+  category:
+    description: One of `pr`, `nightly`, `weekly`, `ondemand`, `target`, `baseline`.
+    required: true
+  suite:
+    description: One of `huggingface`, `timm_models`, `torchbench`, `pt2e`.
+    required: true
+  config:
+    description: Path to the YAML config.
+    required: false
+    default: .ci/config/e2e_matrix.yaml
+  override-dt:
+    description: Used as `dt` for `ondemand`/`target`/`baseline`.
+    required: false
+    default: ''
+  override-mode:
+    description: Used as `mode` for `ondemand`/`target`/`baseline`.
+    required: false
+    default: ''
+  override-scenario:
+    description: Used as `scenario` for `ondemand`/`target`/`baseline`.
+    required: false
+    default: ''
+
+outputs:
+  enabled:
+    description: '"true" if the suite should run for this category, else "false".'
+    value: ${{ steps.resolve.outputs.enabled }}
+  dt:
+    description: Resolved comma-separated dtypes.
+    value: ${{ steps.resolve.outputs.dt }}
+  mode:
+    description: Resolved comma-separated modes (empty for pt2e).
+    value: ${{ steps.resolve.outputs.mode }}
+  scenario:
+    description: Resolved comma-separated scenarios.
+    value: ${{ steps.resolve.outputs.scenario }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve matrix
+      id: resolve
+      shell: bash
+      env:
+        CATEGORY: ${{ inputs.category }}
+        SUITE: ${{ inputs.suite }}
+        CONFIG: ${{ inputs.config }}
+        OVERRIDE_DT: ${{ inputs.override-dt }}
+        OVERRIDE_MODE: ${{ inputs.override-mode }}
+        OVERRIDE_SCENARIO: ${{ inputs.override-scenario }}
+      run: |
+        set -euo pipefail
+        python3 - <<'PY' >> "${GITHUB_OUTPUT}"
+        import os, sys
+        try:
+            import yaml
+        except ImportError:
+            import subprocess
+            subprocess.check_call([sys.executable, "-m", "pip", "install", "--quiet", "pyyaml"])
+            import yaml
+
+        category = os.environ["CATEGORY"].strip()
+        suite    = os.environ["SUITE"].strip()
+        config   = os.environ["CONFIG"]
+
+        # E2E vs PT2E filter (override-driven categories must drop dtypes the
+        # suite cannot run).
+        E2E_DT  = {"float32", "bfloat16", "float16", "amp_bf16", "amp_fp16"}
+        PT2E_DT = {"float32", "int8"}
+
+        def filter_dt(csv: str, suite: str) -> str:
+            allowed = PT2E_DT if suite == "pt2e" else E2E_DT
+            kept = [d.strip() for d in csv.split(",") if d.strip() in allowed]
+            return ",".join(kept)
+
+        def emit(enabled: bool, dt: str = "", mode: str = "", scenario: str = ""):
+            print(f"enabled={'true' if enabled else 'false'}")
+            print(f"dt={dt}")
+            print(f"mode={mode}")
+            print(f"scenario={scenario}")
+
+        # Override-driven categories.
+        if category in ("ondemand", "target", "baseline"):
+            dt = filter_dt(os.environ.get("OVERRIDE_DT", ""), suite)
+            if not dt:
+                emit(False)
+                sys.exit(0)
+            mode = "" if suite == "pt2e" else os.environ.get("OVERRIDE_MODE", "")
+            scenario = os.environ.get("OVERRIDE_SCENARIO", "")
+            emit(True, dt, mode, scenario)
+            sys.exit(0)
+
+        # Config-driven categories.
+        with open(config) as fh:
+            data = yaml.safe_load(fh) or {}
+        bucket = data.get(category, {})
+        suite_cfg = bucket.get(suite)
+        if not suite_cfg:
+            emit(False)
+            sys.exit(0)
+        emit(
+            True,
+            suite_cfg.get("dt", ""),
+            suite_cfg.get("mode", ""),
+            suite_cfg.get("scenario", ""),
+        )
+        PY

--- a/.github/actions/run-e2e-suite/action.yml
+++ b/.github/actions/run-e2e-suite/action.yml
@@ -1,0 +1,132 @@
+name: run-e2e-suite
+description: |
+  Run an Inductor E2E (dynamo benchmark) suite for one (suite, dt, mode,
+  scenario) combination. Wraps `.github/scripts/run_benchmark.py` with:
+    - oneAPI sourcing (when `XPU_ONEAPI_PATH` is set),
+    - model-list resolution from `.ci/benchmarks/models_list.txt`
+      (skipped for `pr`, `target`, `baseline`),
+    - `--model-only` override,
+    - `NUM_GPUS` derivation from `ZE_AFFINITY_MASK`,
+    - structured failure annotations on non-zero exit.
+
+inputs:
+  suite:
+    description: 'huggingface | timm_models | torchbench'
+    required: true
+  dt:
+    description: Comma-separated dtypes.
+    required: true
+  mode:
+    description: Comma-separated modes.
+    required: true
+  scenario:
+    description: Comma-separated scenarios.
+    required: true
+  category:
+    description: Category (controls model-list resolution).
+    required: false
+    default: ondemand
+  model:
+    description: Optional `--model-only` override (single model name).
+    required: false
+    default: ''
+  pytorch-src:
+    description: PyTorch source directory (where `run_benchmark.py` is staged).
+    required: false
+    default: ${{ github.workspace }}/pytorch
+  benchmarks-config-dir:
+    description: Path to `.ci/benchmarks/` (model lists, suite YAMLs).
+    required: false
+    default: ${{ github.workspace }}/.ci/benchmarks
+  scripts-dir:
+    description: Path to `.github/scripts/` (where `run_benchmark.py` lives).
+    required: false
+    default: ${{ github.workspace }}/.github/scripts
+  xpu-ops-dir:
+    description: Path to torch-xpu-ops checkout (for `env.sh`).
+    required: false
+    default: ${{ github.workspace }}/torch-xpu-ops
+
+runs:
+  using: composite
+  steps:
+    - name: Run E2E (${{ inputs.suite }} / ${{ inputs.dt }} / ${{ inputs.mode }} / ${{ inputs.scenario }})
+      shell: bash
+      env:
+        E2E_SUITE: ${{ inputs.suite }}
+        E2E_DT: ${{ inputs.dt }}
+        E2E_MODE: ${{ inputs.mode }}
+        E2E_SCENARIO: ${{ inputs.scenario }}
+        E2E_CATEGORY: ${{ inputs.category }}
+        E2E_MODEL: ${{ inputs.model }}
+        PYTORCH_SRC: ${{ inputs.pytorch-src }}
+        BENCH_CFG_DIR: ${{ inputs.benchmarks-config-dir }}
+        SCRIPTS_DIR: ${{ inputs.scripts-dir }}
+        XPU_OPS_DIR: ${{ inputs.xpu-ops-dir }}
+      run: |
+        set -euo pipefail
+
+        if [[ -z "${E2E_DT}" ]]; then
+          echo "::warning title=Skipping E2E::Empty dt for suite=${E2E_SUITE}"
+          exit 0
+        fi
+
+        # Source oneAPI when present (best-effort).
+        if [[ -n "${XPU_ONEAPI_PATH:-}" && -f "${XPU_OPS_DIR}/.github/scripts/env.sh" ]]; then
+          # shellcheck disable=SC1091
+          source "${XPU_OPS_DIR}/.github/scripts/env.sh" || true
+        fi
+
+        # Locate run_benchmark.py.
+        driver="${SCRIPTS_DIR}/run_benchmark.py"
+        if [[ ! -f "${driver}" ]]; then
+          echo "::error title=run_benchmark.py missing::Expected at ${driver}"
+          exit 1
+        fi
+        cp "${driver}" "${PYTORCH_SRC}/"
+
+        cd "${PYTORCH_SRC}"
+        rm -rf torch inductor_log ~/.triton /tmp/torchinductor_*
+
+        # Build --model-only argument.
+        model_args=()
+        if [[ -n "${E2E_MODEL}" ]]; then
+          model_args+=(--model-only "${E2E_MODEL}")
+        elif [[ "${E2E_CATEGORY}" != "pr" && "${E2E_CATEGORY}" != "target" && "${E2E_CATEGORY}" != "baseline" ]]; then
+          if [[ -d "${BENCH_CFG_DIR}" ]]; then
+            rsync -a "${BENCH_CFG_DIR}/" ./benchmarks/dynamo/
+            list="${BENCH_CFG_DIR}/models_list.txt"
+            if [[ -f "${list}" ]]; then
+              model_args+=(--model-only "${list}")
+            fi
+          fi
+        fi
+
+        # Derive NUM_GPUS from ZE_AFFINITY_MASK if not set.
+        if [[ -z "${NUM_GPUS:-}" && -n "${ZE_AFFINITY_MASK:-}" ]]; then
+          export NUM_GPUS
+          NUM_GPUS=$(awk -F, '{print NF}' <<<"${ZE_AFFINITY_MASK}")
+        fi
+        echo "NUM_GPUS=${NUM_GPUS:-unset}  ZE_AFFINITY_MASK=${ZE_AFFINITY_MASK:-unset}"
+
+        rc=0
+        python ./run_benchmark.py \
+          --suite "${E2E_SUITE}" \
+          --dt "${E2E_DT}" \
+          --mode "${E2E_MODE}" \
+          --scenario "${E2E_SCENARIO}" \
+          "${model_args[@]}" || rc=$?
+
+        if [[ "${rc}" -ne 0 ]]; then
+          echo "::error title=E2E failed::suite=${E2E_SUITE} dt=${E2E_DT} mode=${E2E_MODE} scenario=${E2E_SCENARIO} (exit ${rc})"
+        fi
+
+        {
+          echo "## E2E run: \`${E2E_SUITE}\`"
+          echo
+          echo "| dt | mode | scenario | category | exit |"
+          echo "|----|------|----------|----------|------|"
+          echo "| \`${E2E_DT}\` | \`${E2E_MODE}\` | \`${E2E_SCENARIO}\` | \`${E2E_CATEGORY}\` | ${rc} |"
+        } >> "${GITHUB_STEP_SUMMARY:-/dev/null}" || true
+
+        exit "${rc}"

--- a/.github/actions/summarize-e2e/action.yml
+++ b/.github/actions/summarize-e2e/action.yml
@@ -1,0 +1,133 @@
+name: summarize-e2e
+description: |
+  Scan an Inductor `inductor_log/` directory for accuracy/performance CSVs
+  produced by `run_benchmark.py`, classify each row, and emit:
+    - a per-CSV counts table to `$GITHUB_STEP_SUMMARY`,
+    - a "failed models" list (collapsed `<details>` block),
+    - an `e2e-summary.md` artifact in the log dir.
+
+  The action is best-effort: parsing errors do not fail the step.
+
+inputs:
+  log-dir:
+    description: Directory containing inductor CSV logs (recursive scan).
+    required: false
+    default: ${{ github.workspace }}/pytorch/inductor_log
+  fail-on-failure:
+    description: Whether to exit non-zero when any failed model is found.
+    required: false
+    default: 'false'
+
+outputs:
+  total:
+    description: Total result rows across all CSVs.
+    value: ${{ steps.summarize.outputs.total }}
+  passed:
+    description: Number of passed rows.
+    value: ${{ steps.summarize.outputs.passed }}
+  failed:
+    description: Number of failed rows.
+    value: ${{ steps.summarize.outputs.failed }}
+
+runs:
+  using: composite
+  steps:
+    - name: Summarize
+      id: summarize
+      shell: bash
+      env:
+        LOG_DIR: ${{ inputs.log-dir }}
+        FAIL_ON_FAILURE: ${{ inputs.fail-on-failure }}
+      run: |
+        set -uo pipefail
+        python3 - "$LOG_DIR" >> "${GITHUB_OUTPUT}" <<'PY'
+        import csv, os, re, sys
+        from pathlib import Path
+
+        log_dir = Path(sys.argv[1] if len(sys.argv) > 1 else "")
+        if not log_dir.is_dir():
+            print(f"total=0\npassed=0\nfailed=0")
+            print(f"::warning title=No E2E logs::{log_dir} not found", file=sys.stderr)
+            sys.exit(0)
+
+        csv_files = sorted(log_dir.rglob("inductor-results-*.csv"))
+
+        def classify(row, scenario):
+            if scenario == "accuracy":
+                acc = row.get("accuracy", "").strip().lower()
+                if acc in ("pass", "pass_due_to_skip"):
+                    return "pass"
+                return "fail" if acc else "unknown"
+            # performance: speedup like "1.23x" → pass, "0" / fallback → fail
+            spd = row.get("speedup", "").strip()
+            if re.fullmatch(r"[0-9]+(\.[0-9]+)?x?", spd) and spd not in ("0", "0.0", "0.00"):
+                return "pass"
+            return "fail" if spd else "unknown"
+
+        per_file = []
+        all_failed = []
+        total = passed = failed = 0
+
+        for f in csv_files:
+            try:
+                with f.open(newline="") as fh:
+                    rows = list(csv.DictReader(fh))
+            except Exception as e:
+                print(f"::warning title=Cannot read CSV::{f.name}: {e}", file=sys.stderr)
+                continue
+            t = p = ff = 0
+            for row in rows:
+                scenario = (row.get("scenario") or "").strip()
+                status = classify(row, scenario)
+                t += 1
+                if status == "pass":
+                    p += 1
+                elif status == "fail":
+                    ff += 1
+                    all_failed.append((
+                        row.get("suite", ""), row.get("dtype", ""),
+                        row.get("mode", ""), scenario,
+                        row.get("name", ""),
+                        row.get("accuracy") or row.get("speedup") or "",
+                    ))
+            per_file.append((f.relative_to(log_dir), t, p, ff))
+            total += t; passed += p; failed += ff
+
+        # Step output
+        print(f"total={total}")
+        print(f"passed={passed}")
+        print(f"failed={failed}")
+
+        # Step summary
+        sumpath = os.environ.get("GITHUB_STEP_SUMMARY")
+        if sumpath:
+            with open(sumpath, "a") as out:
+                out.write("## E2E summary\n\n")
+                if total == 0:
+                    out.write("_No result rows found._\n")
+                else:
+                    pct = (passed * 100 // total) if total else 0
+                    out.write(f"**{passed}/{total} passed ({pct}%)** — {failed} failed.\n\n")
+                    out.write("| File | Total | Passed | Failed |\n|---|---:|---:|---:|\n")
+                    for name, t, p, ff in per_file:
+                        out.write(f"| `{name}` | {t} | {p} | {ff} |\n")
+                if all_failed:
+                    out.write("\n<details><summary>Failed models</summary>\n\n")
+                    out.write("| suite | dtype | mode | scenario | model | result |\n")
+                    out.write("|---|---|---|---|---|---|\n")
+                    for s, d, m, sc, n, r in all_failed[:200]:
+                        out.write(f"| {s} | {d} | {m} | {sc} | {n} | `{r}` |\n")
+                    if len(all_failed) > 200:
+                        out.write(f"\n_…and {len(all_failed) - 200} more_\n")
+                    out.write("\n</details>\n")
+
+        # Markdown artifact
+        try:
+            with (log_dir / "e2e-summary.md").open("w") as out:
+                out.write(f"# E2E summary\n\nTotal: {total}, Passed: {passed}, Failed: {failed}\n")
+        except Exception:
+            pass
+
+        if os.environ.get("FAIL_ON_FAILURE") == "true" and failed:
+            sys.exit(1)
+        PY

--- a/.github/workflows/_linux_e2e.yml
+++ b/.github/workflows/_linux_e2e.yml
@@ -22,19 +22,25 @@ on:
       suite:
         type: string
         default: huggingface
-        description: 'Suite: huggingface, timm_models, torchbench, pt2e'
+        description: |
+          Comma-separated suite list. Allowed: huggingface, timm_models,
+          torchbench, pt2e. Suites not configured for the current category
+          are skipped.
       dt:
         type: string
         default: float32
-        description: 'Dtypes: float32, bfloat16, float16, amp_bf16, amp_fp16, int8'
+        description: |
+          Comma-separated dtypes (used by `ondemand`/`target`/`baseline`).
+          For other categories the matrix is read from
+          `.ci/config/e2e_matrix.yaml`.
       mode:
         type: string
         default: inference
-        description: 'Modes: inference, training'
+        description: 'Modes (used by ondemand/target/baseline): inference, training'
       scenario:
         type: string
         default: accuracy
-        description: 'Scenarios: accuracy, performance'
+        description: 'Scenarios (used by ondemand/target/baseline): accuracy, performance'
       model:
         type: string
         required: false
@@ -43,7 +49,7 @@ on:
       category:
         type: string
         default: default
-        description: Category for test comparison
+        description: 'Category: pr, nightly, weekly, ondemand, target, baseline'
       component:
         type: string
         default: ''
@@ -118,6 +124,7 @@ jobs:
       CATEGORY: ${{ inputs.category }}
       MODEL_ONLY_NAME: ${{ inputs.model }}
       WORKSPACE: ${{ github.workspace }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -134,190 +141,135 @@ jobs:
           component_version: ${{ inputs.component_version }}
           category: ${{ inputs.category }}
 
-      - name: Parse suite configuration
-        id: parse-suites
+      # ── Suite selection: split inputs.suite into per-suite booleans ───────
+      - name: Detect requested suites
+        id: suites
         run: |
-          IFS=',' read -ra suites <<< "${{ inputs.suite }}"
-          for s in "${suites[@]}"; do
-            s="${s// /}"
-            case "$s" in
-              huggingface)  echo "HAS_HUGGINGFACE=1" >> "$GITHUB_OUTPUT" ;;
-              timm_models)  echo "HAS_TIMM_MODELS=1" >> "$GITHUB_OUTPUT" ;;
-              torchbench)   echo "HAS_TORCHBENCH=1"  >> "$GITHUB_OUTPUT" ;;
-              pt2e)         echo "HAS_PT2E=1"        >> "$GITHUB_OUTPUT" ;;
-            esac
+          IFS=',' read -ra requested <<< "${{ inputs.suite }}"
+          for s in huggingface timm_models torchbench pt2e; do
+            on=false
+            for r in "${requested[@]}"; do
+              [[ "${r// /}" == "${s}" ]] && on=true && break
+            done
+            echo "${s}=${on}" >> "${GITHUB_OUTPUT}"
           done
 
-      # ── CI/CD (pull request) ──────────────────────────────────────────────
-      - name: CI/CD — huggingface
-        if: inputs.category == 'pr' && steps.parse-suites.outputs.HAS_HUGGINGFACE == '1'
-        uses: ./.github/actions/linux-e2etest
+      # ── HuggingFace ───────────────────────────────────────────────────────
+      - name: Resolve matrix — huggingface
+        id: matrix-hf
+        if: steps.suites.outputs.huggingface == 'true'
+        uses: ./.github/actions/resolve-e2e-matrix
+        with:
+          category: ${{ inputs.category }}
+          suite: huggingface
+          override-dt: ${{ inputs.dt }}
+          override-mode: ${{ inputs.mode }}
+          override-scenario: ${{ inputs.scenario }}
+
+      - name: Run E2E — huggingface
+        if: steps.suites.outputs.huggingface == 'true' && steps.matrix-hf.outputs.enabled == 'true'
+        uses: ./.github/actions/run-e2e-suite
         with:
           suite: huggingface
-          dt: bfloat16,float16
-          mode: training
-          scenario: accuracy,performance
+          dt: ${{ steps.matrix-hf.outputs.dt }}
+          mode: ${{ steps.matrix-hf.outputs.mode }}
+          scenario: ${{ steps.matrix-hf.outputs.scenario }}
+          category: ${{ inputs.category }}
+          model: ${{ inputs.model }}
 
-      - name: CI/CD — timm_models
-        if: inputs.category == 'pr' && steps.parse-suites.outputs.HAS_TIMM_MODELS == '1'
-        uses: ./.github/actions/linux-e2etest
+      # ── timm_models ───────────────────────────────────────────────────────
+      - name: Resolve matrix — timm_models
+        id: matrix-timm
+        if: steps.suites.outputs.timm_models == 'true'
+        uses: ./.github/actions/resolve-e2e-matrix
+        with:
+          category: ${{ inputs.category }}
+          suite: timm_models
+          override-dt: ${{ inputs.dt }}
+          override-mode: ${{ inputs.mode }}
+          override-scenario: ${{ inputs.scenario }}
+
+      - name: Run E2E — timm_models
+        if: steps.suites.outputs.timm_models == 'true' && steps.matrix-timm.outputs.enabled == 'true'
+        uses: ./.github/actions/run-e2e-suite
         with:
           suite: timm_models
-          dt: bfloat16
-          mode: training
-          scenario: accuracy,performance
+          dt: ${{ steps.matrix-timm.outputs.dt }}
+          mode: ${{ steps.matrix-timm.outputs.mode }}
+          scenario: ${{ steps.matrix-timm.outputs.scenario }}
+          category: ${{ inputs.category }}
+          model: ${{ inputs.model }}
 
-      - name: CI/CD — torchbench
-        if: inputs.category == 'pr' && steps.parse-suites.outputs.HAS_TORCHBENCH == '1'
-        uses: ./.github/actions/linux-e2etest
+      # ── torchbench ────────────────────────────────────────────────────────
+      - name: Resolve matrix — torchbench
+        id: matrix-tb
+        if: steps.suites.outputs.torchbench == 'true'
+        uses: ./.github/actions/resolve-e2e-matrix
+        with:
+          category: ${{ inputs.category }}
+          suite: torchbench
+          override-dt: ${{ inputs.dt }}
+          override-mode: ${{ inputs.mode }}
+          override-scenario: ${{ inputs.scenario }}
+
+      - name: Run E2E — torchbench
+        if: steps.suites.outputs.torchbench == 'true' && steps.matrix-tb.outputs.enabled == 'true'
+        uses: ./.github/actions/run-e2e-suite
         with:
           suite: torchbench
-          dt: bfloat16
-          mode: training
-          scenario: accuracy,performance
+          dt: ${{ steps.matrix-tb.outputs.dt }}
+          mode: ${{ steps.matrix-tb.outputs.mode }}
+          scenario: ${{ steps.matrix-tb.outputs.scenario }}
+          category: ${{ inputs.category }}
+          model: ${{ inputs.model }}
 
-      # ── Nightly ───────────────────────────────────────────────────────────
-      - name: Nightly — huggingface
-        if: inputs.category == 'nightly' && steps.parse-suites.outputs.HAS_HUGGINGFACE == '1'
-        uses: ./.github/actions/linux-e2etest
+      # ── PT2E (resolves dt/scenario only; no mode) ─────────────────────────
+      - name: Resolve matrix — pt2e
+        id: matrix-pt2e
+        if: steps.suites.outputs.pt2e == 'true'
+        uses: ./.github/actions/resolve-e2e-matrix
         with:
-          suite: huggingface
-          dt: float32,bfloat16,float16,amp_bf16,amp_fp16
-          mode: inference,training
-          scenario: accuracy,performance
+          category: ${{ inputs.category }}
+          suite: pt2e
+          override-dt: ${{ inputs.dt }}
+          override-scenario: ${{ inputs.scenario }}
 
-      - name: Nightly — timm_models
-        if: inputs.category == 'nightly' && steps.parse-suites.outputs.HAS_TIMM_MODELS == '1'
-        uses: ./.github/actions/linux-e2etest
-        with:
-          suite: timm_models
-          dt: float16,bfloat16
-          mode: training
-          scenario: accuracy,performance
-
-      - name: Nightly — torchbench
-        if: inputs.category == 'nightly' && steps.parse-suites.outputs.HAS_TORCHBENCH == '1'
-        uses: ./.github/actions/linux-e2etest
-        with:
-          suite: torchbench
-          dt: float16,bfloat16
-          mode: training
-          scenario: accuracy,performance
-
-      - name: Nightly — pt2e
-        if: inputs.category == 'nightly' && steps.parse-suites.outputs.HAS_PT2E == '1'
+      - name: Run PT2E
+        if: steps.suites.outputs.pt2e == 'true' && steps.matrix-pt2e.outputs.enabled == 'true'
         uses: ./.github/actions/pt2e
         with:
-          dt: float32,int8
-          scenario: accuracy,performance
+          dt: ${{ steps.matrix-pt2e.outputs.dt }}
+          scenario: ${{ steps.matrix-pt2e.outputs.scenario }}
 
-      # ── Weekly ────────────────────────────────────────────────────────────
-      - name: Weekly — huggingface
-        if: inputs.category == 'weekly' && steps.parse-suites.outputs.HAS_HUGGINGFACE == '1'
-        uses: ./.github/actions/linux-e2etest
-        with:
-          suite: huggingface
-          dt: float32,bfloat16,float16,amp_bf16,amp_fp16
-          mode: inference,training
-          scenario: accuracy,performance
-
-      - name: Weekly — timm_models
-        if: inputs.category == 'weekly' && steps.parse-suites.outputs.HAS_TIMM_MODELS == '1'
-        uses: ./.github/actions/linux-e2etest
-        with:
-          suite: timm_models
-          dt: float32,bfloat16,float16,amp_bf16,amp_fp16
-          mode: inference,training
-          scenario: accuracy,performance
-
-      - name: Weekly — torchbench
-        if: inputs.category == 'weekly' && steps.parse-suites.outputs.HAS_TORCHBENCH == '1'
-        uses: ./.github/actions/linux-e2etest
-        with:
-          suite: torchbench
-          dt: float32,bfloat16,float16,amp_bf16,amp_fp16
-          mode: inference,training
-          scenario: accuracy,performance
-
-      - name: Weekly — pt2e
-        if: inputs.category == 'weekly' && steps.parse-suites.outputs.HAS_PT2E == '1'
-        uses: ./.github/actions/pt2e
-        with:
-          dt: float32,int8
-          scenario: accuracy,performance
-
-      # ── On-demand ─────────────────────────────────────────────────────────
-      - name: Parse dtypes for on-demand tests
-        id: parse-dtypes
-        if: inputs.category == 'ondemand'
-        run: |
-          # Split dtypes into E2E-valid and PT2E-valid buckets
-          E2E="" ; PT2E=""
-          IFS=',' read -ra dts <<< "${{ inputs.dt }}"
-          for d in "${dts[@]}"; do
-            d="${d// /}"
-            case "$d" in
-              float32|bfloat16|float16|amp_bf16|amp_fp16) E2E="${E2E:+$E2E,}$d" ;;
-            esac
-            case "$d" in
-              float32|int8) PT2E="${PT2E:+$PT2E,}$d" ;;
-            esac
-          done
-          echo "E2E_DTYPES=${E2E:-float32}"   >> "$GITHUB_OUTPUT"
-          echo "PT2E_DTYPES=${PT2E:-float32}" >> "$GITHUB_OUTPUT"
-
-      - name: On-demand — huggingface
-        if: inputs.category == 'ondemand' && steps.parse-suites.outputs.HAS_HUGGINGFACE == '1'
-        uses: ./.github/actions/linux-e2etest
-        with:
-          suite: huggingface
-          dt: ${{ steps.parse-dtypes.outputs.E2E_DTYPES }}
-          mode: ${{ inputs.mode }}
-          scenario: ${{ inputs.scenario }}
-
-      - name: On-demand — timm_models
-        if: inputs.category == 'ondemand' && steps.parse-suites.outputs.HAS_TIMM_MODELS == '1'
-        uses: ./.github/actions/linux-e2etest
-        with:
-          suite: timm_models
-          dt: ${{ steps.parse-dtypes.outputs.E2E_DTYPES }}
-          mode: ${{ inputs.mode }}
-          scenario: ${{ inputs.scenario }}
-
-      - name: On-demand — torchbench
-        if: inputs.category == 'ondemand' && steps.parse-suites.outputs.HAS_TORCHBENCH == '1'
-        uses: ./.github/actions/linux-e2etest
-        with:
-          suite: torchbench
-          dt: ${{ steps.parse-dtypes.outputs.E2E_DTYPES }}
-          mode: ${{ inputs.mode }}
-          scenario: ${{ inputs.scenario }}
-
-      - name: On-demand — pt2e
-        if: inputs.category == 'ondemand' && steps.parse-suites.outputs.HAS_PT2E == '1'
-        uses: ./.github/actions/pt2e
-        with:
-          dt: ${{ steps.parse-dtypes.outputs.PT2E_DTYPES }}
-          scenario: ${{ inputs.scenario }}
-
-      # ── Comparison (target / baseline) ────────────────────────────────────
-      - name: Comparison — training
+      # ── Comparison categories use a fixed two-pass matrix ────────────────
+      - name: Comparison — training (amp_fp16)
         if: inputs.category == 'target' || inputs.category == 'baseline'
-        uses: ./.github/actions/linux-e2etest
+        uses: ./.github/actions/run-e2e-suite
         with:
           suite: ${{ inputs.suite }}
           dt: amp_fp16
           mode: training
           scenario: accuracy,performance
+          category: ${{ inputs.category }}
+          model: ${{ inputs.model }}
 
-      - name: Comparison — inference
+      - name: Comparison — inference (bfloat16)
         if: inputs.category == 'target' || inputs.category == 'baseline'
-        uses: ./.github/actions/linux-e2etest
+        uses: ./.github/actions/run-e2e-suite
         with:
           suite: ${{ inputs.suite }}
           dt: bfloat16
           mode: inference
           scenario: accuracy,performance
+          category: ${{ inputs.category }}
+          model: ${{ inputs.model }}
+
+      # ── Summary ───────────────────────────────────────────────────────────
+      - name: Summarize results
+        if: ${{ ! cancelled() }}
+        uses: ./.github/actions/summarize-e2e
+        with:
+          log-dir: ${{ env.WORKSPACE }}/pytorch/inductor_log
 
       # ── Collect & upload artifacts ────────────────────────────────────────
       - name: Collect test artifacts


### PR DESCRIPTION
## Summary

Third PR in the CI/CD refactor series. Replaces 14 nearly-identical hardcoded test-matrix steps in `_linux_e2e.yml` with a single data-driven config and three new composite actions, and adds a structured E2E summary that highlights failed models in the GitHub job UI.

> **Stacked on:** #12 - Refactor build (which is stacked on #11). Review/merge those first.

## Why

The old `_linux_e2e.yml` had 14 `Run e2e` steps - one for each (category x suite) cell - each hardcoding its own `dt/mode/scenario` values. Adding a dtype meant editing N steps; the matrix wasn't visible in one place; and there was no failure summary.

## Changes

### New config
```
.ci/config/e2e_matrix.yaml      # single source of truth for category -> suite -> (dt, mode, scenario)
```

### New composite actions

| Action | Purpose |
|---|---|
| `resolve-e2e-matrix` | Reads the YAML and outputs resolved `dt/mode/scenario` for a (category, suite). Skips suites not configured for the category. Supports `ondemand/target/baseline` overrides and auto-filters E2E vs PT2E dtypes. |
| `run-e2e-suite` | Replaces `linux-e2etest`. Wraps `run_benchmark.py` with oneAPI sourcing, model-list resolution (skipped for `pr/target/baseline`), `--model-only` override, `NUM_GPUS` derivation from `ZE_AFFINITY_MASK`, and `::error::` annotations on non-zero exit. Emits a step-summary row per run. |
| `summarize-e2e` | Scans `inductor_log/` for `inductor-results-*.csv`, classifies each row, and emits a per-file counts table plus a collapsed *Failed models* table to `$GITHUB_STEP_SUMMARY`. Best-effort - parsing errors don't fail the step. |

### Refactored workflow

`_linux_e2e.yml`: the 14 hardcoded category branches collapse into four `(resolve -> run)` pairs (huggingface / timm_models / torchbench / pt2e) + a comparison fallback for target/baseline + the new summary step.

## Behavior

- Each category x suite cell produces the same matrix as before (verified by porting the existing values into `e2e_matrix.yaml` 1:1).
- `pt2e` ignores `mode` (no change).
- `pr/target/baseline` still skip the model-list file.
- New: failed models appear collapsed under *Failed models* in the GitHub step summary, making regressions visible without downloading artifacts.

Net: 5 files changed, **+554 / -151**.

## Roadmap

- PR 1: code check (#11)
- PR 2: build (#12)
- **PR 3: dynamo benchmark / E2E (this)**
- Next: unit tests, distributed, microbench, accelerate, transformers, unified reporting.
