### PR TITLE
Refactor UT pipeline: per-suite scripts + summary action

### DIFF
--- a/.ci/scripts/ut/_lib.sh
+++ b/.ci/scripts/ut/_lib.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Shared helpers for UT scripts.
+# Each suite script is invoked with cwd=$GITHUB_WORKSPACE and inherits
+# WORKSPACE, PYTEST_ADDOPTS, ZE_AFFINITY_MASK, XPU_ONEAPI_PATH, etc.
+
+set -euo pipefail
+
+: "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}"
+: "${WORKSPACE:=${GITHUB_WORKSPACE}}"
+
+ut::source_oneapi() {
+    if [[ -n "${XPU_ONEAPI_PATH:-}" ]]; then
+        local env_sh="${WORKSPACE}/torch-xpu-ops/.github/scripts/env.sh"
+        if [[ -f "${env_sh}" ]]; then
+            # shellcheck disable=SC1090
+            source "${env_sh}"
+        elif [[ -f "${XPU_ONEAPI_PATH}/setvars.sh" ]]; then
+            # shellcheck disable=SC1091
+            source "${XPU_ONEAPI_PATH}/setvars.sh"
+        fi
+    fi
+}
+
+ut::log_dir() {
+    local name="${1:?suite name required}"
+    local dir="${GITHUB_WORKSPACE}/ut_log/${name}"
+    mkdir -p "${dir}"
+    printf '%s' "${dir}"
+}
+
+ut::reproduce() {
+    local name="${1:?}" cmd="${2:?}"
+    echo "Reproduce: ${cmd}" \
+        | tee "${GITHUB_WORKSPACE}/ut_log/reproduce_${name}.log" >/dev/null
+}
+
+ut::ops_dir() {
+    printf '%s/pytorch/third_party/torch-xpu-ops' "${GITHUB_WORKSPACE}"
+}

--- a/.ci/scripts/ut/op_extended.sh
+++ b/.ci/scripts/ut/op_extended.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+export PYTORCH_TEST_WITH_SLOW=1
+
+ut::source_oneapi
+LOG_DIR="$(ut::log_dir op_extended)"
+
+cd "$(ut::ops_dir)/test/xpu/extended"
+
+python run_test_with_skip.py \
+    2> "${LOG_DIR}/op_extended_test_error.log" \
+    | tee "${LOG_DIR}/op_extended_test.log" || true
+
+cp -f *.xml "${GITHUB_WORKSPACE}/ut_log/" 2>/dev/null || true
+
+ut::reproduce op_extended "cd $(pwd) && pytest -sv <failed_case>"

--- a/.ci/scripts/ut/op_p0.sh
+++ b/.ci/scripts/ut/op_p0.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+export PYTORCH_TEST_WITH_SLOW=1
+export PYTORCH_ROOT_DIR="${GITHUB_WORKSPACE}/pytorch"
+export XML_OUTPUT_DIR="${GITHUB_WORKSPACE}/ut_log"
+export XML_PREFIX=op_p0_with_
+
+ut::source_oneapi
+LOG_DIR="$(ut::log_dir op_p0)"
+
+cd "${GITHUB_WORKSPACE}/pytorch/"
+
+"${GITHUB_WORKSPACE}/.ci/benchmarks/p0/run_ut.sh" \
+    2> "${LOG_DIR}/op_p0_with_skip_test_error.log" \
+    | tee "${LOG_DIR}/op_p0_with_skip_test.log" || true
+
+find . -name "op_p0_with_*.xml" -exec cp {} "${GITHUB_WORKSPACE}/ut_log/" \; 2>/dev/null || true
+
+ut::reproduce op_p0 "cd $(pwd) && pytest -sv <failed_case>"

--- a/.ci/scripts/ut/op_regression.sh
+++ b/.ci/scripts/ut/op_regression.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+ut::source_oneapi
+LOG_DIR="$(ut::log_dir op_regression)"
+
+cd "$(ut::ops_dir)/test/regressions"
+
+pytest --junit-xml="${GITHUB_WORKSPACE}/ut_log/op_regression.xml" \
+    2> "${LOG_DIR}/op_regression_test_error.log" \
+    | tee "${LOG_DIR}/op_regression_test.log" || true
+
+ut::reproduce op_regression "cd $(pwd) && pytest -sv <failed_case>"

--- a/.ci/scripts/ut/op_regression_dev1.sh
+++ b/.ci/scripts/ut/op_regression_dev1.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+ut::source_oneapi
+LOG_DIR="$(ut::log_dir op_regression_dev1)"
+
+cd "$(ut::ops_dir)/test/regressions"
+
+unset PYTEST_ADDOPTS ZE_AFFINITY_MASK
+timeout 180 pytest -v test_operation_on_device_1.py \
+    --junit-xml="${GITHUB_WORKSPACE}/ut_log/op_regression_dev1.xml" \
+    2> "${LOG_DIR}/op_regression_dev1_test_error.log" \
+    | tee "${LOG_DIR}/op_regression_dev1_test.log" || true
+
+ut::reproduce op_regression_dev1 "cd $(pwd) && pytest -sv test_operation_on_device_1.py"

--- a/.ci/scripts/ut/op_ut.sh
+++ b/.ci/scripts/ut/op_ut.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+export PYTORCH_TEST_WITH_SLOW=1
+
+ut::source_oneapi
+LOG_DIR="$(ut::log_dir op_ut)"
+
+cd "$(ut::ops_dir)/test/xpu"
+
+python run_test_with_skip.py \
+    2> "${LOG_DIR}/op_ut_with_skip_test_error.log" \
+    | tee "${LOG_DIR}/op_ut_with_skip_test.log" || true
+
+find . -name "op_ut_with_*.xml" -exec cp {} "${GITHUB_WORKSPACE}/ut_log/" \; 2>/dev/null || true
+
+ut::reproduce op_ut "cd $(pwd) && pytest -sv <failed_case>"

--- a/.ci/scripts/ut/skipped_ut.sh
+++ b/.ci/scripts/ut/skipped_ut.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+export PYTORCH_TEST_WITH_SLOW=1
+
+ut::source_oneapi
+LOG_DIR="$(ut::log_dir skipped_ut)"
+
+cd "$(ut::ops_dir)/test/xpu"
+
+# Skipped tests need a longer per-test timeout.
+export PYTEST_ADDOPTS="${PYTEST_ADDOPTS//--timeout 600/--timeout 3600}"
+python run_test_with_skip.py --test-cases skipped \
+    2> "${LOG_DIR}/skipped_ut_with_skip_test_error.log" \
+    | tee "${LOG_DIR}/skipped_ut_with_skip_test.log" || true
+
+find . -name "op_ut_with_*.xml" -exec cp {} "${GITHUB_WORKSPACE}/ut_log/" \; 2>/dev/null || true
+
+ut::reproduce skipped_ut "cd $(pwd) && pytest -sv <failed_case>"

--- a/.ci/scripts/ut/torch_xpu.sh
+++ b/.ci/scripts/ut/torch_xpu.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+export PYTORCH_TEST_WITH_SLOW=1
+export PYTORCH_TESTING_DEVICE_ONLY_FOR=xpu
+
+ut::source_oneapi
+LOG_DIR="$(ut::log_dir torch_xpu)"
+
+cd "${GITHUB_WORKSPACE}/pytorch"
+
+# Collect all inductor + xpu test files
+TEST_INCLUDES=""
+for f in test/inductor/test_*.py; do
+    [[ -f "$f" ]] && TEST_INCLUDES+=" inductor/$(basename "$f")"
+done
+for f in test/xpu/test_*.py; do
+    [[ -f "$f" ]] && TEST_INCLUDES+=" xpu/$(basename "$f")"
+done
+[[ -f "test/test_xpu.py" ]] && TEST_INCLUDES+=" test_xpu.py"
+
+# shellcheck disable=SC2086
+python test/run_test.py --include ${TEST_INCLUDES} \
+    2> "${LOG_DIR}/torch_xpu_test_error.log" \
+    | tee "${LOG_DIR}/torch_xpu_test.log" || true

--- a/.ci/scripts/ut/xpu_distributed.sh
+++ b/.ci/scripts/ut/xpu_distributed.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+ut::source_oneapi
+LOG_DIR="$(ut::log_dir xpu_distributed)"
+
+xpu-smi topology -m 2>/dev/null || true
+
+cd "$(ut::ops_dir)/test/xpu"
+
+# Verify XCCL availability before running.
+XCCL=$(python -c "import torch; print(torch.distributed.is_xccl_available())" 2>/dev/null || echo False)
+if [[ "${XCCL}" != "True" ]]; then
+    echo "::error::XCCL not available"
+    exit 1
+fi
+
+python run_distributed.py \
+    2> "${LOG_DIR}/xpu_distributed_test_error.log" \
+    | tee "${LOG_DIR}/xpu_distributed_test.log" || true
+
+find .. -name "*.xml" -exec cp {} "${GITHUB_WORKSPACE}/ut_log/" \; 2>/dev/null || true

--- a/.ci/scripts/ut/xpu_profiling.sh
+++ b/.ci/scripts/ut/xpu_profiling.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+ut::source_oneapi
+LOG_DIR="$(ut::log_dir xpu_profiling)"
+mkdir -p "${LOG_DIR}/issue_reproduce"
+
+cd "$(ut::ops_dir)"
+
+# ResNet50 profiling
+PROFILE=1 python -u test/profiling/rn50.py \
+    -a resnet50 --dummy ./ --num-iterations 20 --xpu 0 || true
+cp -f profiling.fp32.train.pt "${LOG_DIR}/" 2>/dev/null || true
+
+# Issue reproduction tests
+for t in \
+    test/profiling/correlation_id_mixed.py \
+    test/profiling/reproducer.missing.gpu.kernel.time.py \
+    test/profiling/time_precision_in_profile.py \
+    test/profiling/profile_partial_runtime_ops.py \
+    test/profiling/triton_xpu_ops_time.py \
+    test/profiling/test_profiler_correctness.py \
+    test/profiling/test_for_overlapping_kernels.py; do
+    if [[ -f "$t" ]]; then
+        python -u "$t" | tee "${LOG_DIR}/issue_reproduce/$(basename "$t" .py).log" || true
+    fi
+done
+
+# Llama profiling
+pip install -q transformers || true
+if [[ -f "test/profiling/llama.py" ]]; then
+    python test/profiling/llama.py | tee "${LOG_DIR}/llama.log" || true
+    if [[ -f ".github/scripts/llama_summary.py" ]]; then
+        python .github/scripts/llama_summary.py \
+            -i "${LOG_DIR}/llama.log" \
+            -o "${LOG_DIR}/llama_summary.csv" || true
+    fi
+fi
+
+# Upstream profiler tests
+cd "${GITHUB_WORKSPACE}/pytorch/test/profiler"
+for t in test_cpp_thread.py test_execution_trace.py test_memory_profiler.py \
+         test_profiler_tree.py test_xpu_profiler.py; do
+    if [[ -f "$t" ]]; then
+        python -m pytest -s "$t" | tee "${LOG_DIR}/$(basename "$t" .py).log" || true
+    fi
+done

--- a/.github/actions/linux-uttest/action.yml
+++ b/.github/actions/linux-uttest/action.yml
@@ -1,243 +1,76 @@
 name: Linux Unit Test
 description: >-
-  Dispatch a single UT suite by name (op_regression, op_extended, torch_xpu, …)
+  Dispatch one or more UT suites by name. Each suite's logic lives in
+  .ci/scripts/ut/<suite>.sh and is invoked with a per-suite timeout.
 
 inputs:
   ut_name:
     required: true
     description: >-
-      basic, op_regression, op_regression_dev1, op_extended, op_ut,
-      skipped_ut, torch_xpu, xpu_profiling, xpu_distributed, op_p0
+      Suite name. One of:
+        op_regression, op_regression_dev1, op_extended, op_ut, skipped_ut,
+        torch_xpu, xpu_profiling, xpu_distributed, op_p0, basic.
+      "basic" expands to: op_regression, op_regression_dev1, op_extended.
+  scripts_dir:
+    required: false
+    default: ${{ github.workspace }}/.ci/scripts/ut
+    description: Directory containing the per-suite scripts.
 
 runs:
   using: composite
   steps:
-    # ── Environment ─────────────────────────────────────────────────────────
     - name: Log environment
       shell: bash -eo pipefail {0}
       run: |
-        python -V 2>&1
+        python -V 2>&1 || true
         pip list --format=columns 2>/dev/null || true
-        printenv | sort | tee -a "${GITHUB_WORKSPACE}/test_info.log"
+        printenv | sort | tee -a "${GITHUB_WORKSPACE}/test_info.log" >/dev/null
 
-    # ── op_regression ───────────────────────────────────────────────────────
-    - name: op_regression
-      shell: timeout 3600 bash -eo pipefail {0}
-      if: inputs.ut_name == 'op_regression' || inputs.ut_name == 'basic'
+    - name: Run UT suite(s)
+      shell: bash -eo pipefail {0}
       env:
-        LOG_DIR: ${{ github.workspace }}/ut_log/${{ inputs.ut_name }}
+        UT_NAME: ${{ inputs.ut_name }}
+        SCRIPTS_DIR: ${{ inputs.scripts_dir }}
       run: |
-        [[ -n "${XPU_ONEAPI_PATH}" ]] && source "${WORKSPACE}/torch-xpu-ops/.github/scripts/env.sh" || true
-        mkdir -p "${LOG_DIR}"
-        cd "${GITHUB_WORKSPACE}/pytorch/third_party/torch-xpu-ops/test/regressions"
+        # Per-suite timeouts (seconds). Mirrors the previous hardcoded values.
+        declare -A TIMEOUT=(
+          [op_regression]=3600
+          [op_regression_dev1]=300
+          [op_extended]=3600
+          [op_ut]=72000
+          [skipped_ut]=72000
+          [torch_xpu]=72000
+          [xpu_profiling]=3600
+          [xpu_distributed]=36000
+          [op_p0]=72000
+        )
 
-        pytest --junit-xml="${GITHUB_WORKSPACE}/ut_log/op_regression.xml" \
-          2> "${LOG_DIR}/op_regression_test_error.log" \
-          | tee "${LOG_DIR}/op_regression_test.log" || true
+        # "basic" expands to a known set of suites.
+        case "${UT_NAME}" in
+          basic) suites=(op_regression op_regression_dev1 op_extended) ;;
+          *)     suites=("${UT_NAME}") ;;
+        esac
 
-        echo "Reproduce: cd $(pwd) && pytest -sv <failed_case>" \
-          | tee "${GITHUB_WORKSPACE}/ut_log/reproduce_op_regression.log"
+        rc=0
+        for s in "${suites[@]}"; do
+          script="${SCRIPTS_DIR}/${s}.sh"
+          if [[ ! -f "${script}" ]]; then
+            echo "::error::Unknown UT suite '${s}' (expected ${script})"
+            rc=1
+            continue
+          fi
 
-    # ── op_regression_dev1 ──────────────────────────────────────────────────
-    - name: op_regression_dev1
-      shell: timeout 300 bash -eo pipefail {0}
-      if: inputs.ut_name == 'op_regression_dev1' || inputs.ut_name == 'basic'
-      env:
-        LOG_DIR: ${{ github.workspace }}/ut_log/${{ inputs.ut_name }}
-      run: |
-        [[ -n "${XPU_ONEAPI_PATH}" ]] && source "${WORKSPACE}/torch-xpu-ops/.github/scripts/env.sh" || true
-        mkdir -p "${LOG_DIR}"
-        cd "${GITHUB_WORKSPACE}/pytorch/third_party/torch-xpu-ops/test/regressions"
-
-        unset PYTEST_ADDOPTS ZE_AFFINITY_MASK
-        timeout 180 pytest -v test_operation_on_device_1.py \
-          --junit-xml="${GITHUB_WORKSPACE}/ut_log/op_regression_dev1.xml" \
-          2> "${LOG_DIR}/op_regression_dev1_test_error.log" \
-          | tee "${LOG_DIR}/op_regression_dev1_test.log" || true
-
-        echo "Reproduce: cd $(pwd) && pytest -sv test_operation_on_device_1.py" \
-          | tee "${GITHUB_WORKSPACE}/ut_log/reproduce_op_regression_dev1.log"
-
-    # ── op_extended ─────────────────────────────────────────────────────────
-    - name: op_extended
-      shell: timeout 3600 bash -eo pipefail {0}
-      if: inputs.ut_name == 'op_extended' || inputs.ut_name == 'basic'
-      env:
-        LOG_DIR: ${{ github.workspace }}/ut_log/${{ inputs.ut_name }}
-        PYTORCH_TEST_WITH_SLOW: 1
-      run: |
-        [[ -n "${XPU_ONEAPI_PATH}" ]] && source "${WORKSPACE}/torch-xpu-ops/.github/scripts/env.sh" || true
-        mkdir -p "${LOG_DIR}"
-        cd "${GITHUB_WORKSPACE}/pytorch/third_party/torch-xpu-ops/test/xpu/extended"
-
-        python run_test_with_skip.py \
-          2> "${LOG_DIR}/op_extended_test_error.log" \
-          | tee "${LOG_DIR}/op_extended_test.log" || true
-
-        cp -f *.xml "${GITHUB_WORKSPACE}/ut_log/" 2>/dev/null || true
-
-        echo "Reproduce: cd $(pwd) && pytest -sv <failed_case>" \
-          | tee "${GITHUB_WORKSPACE}/ut_log/reproduce_op_extended.log"
-
-    # ── op_ut ───────────────────────────────────────────────────────────────
-    - name: op_ut
-      shell: timeout 72000 bash -eo pipefail {0}
-      if: inputs.ut_name == 'op_ut'
-      env:
-        PYTORCH_TEST_WITH_SLOW: 1
-        LOG_BASE: ${{ github.workspace }}/ut_log/op_ut
-      run: |
-        [[ -n "${XPU_ONEAPI_PATH}" ]] && source "${WORKSPACE}/torch-xpu-ops/.github/scripts/env.sh" || true
-        mkdir -p "${LOG_BASE}"
-        cd "${GITHUB_WORKSPACE}/pytorch/third_party/torch-xpu-ops/test/xpu"
-
-        python run_test_with_skip.py \
-          2> "${LOG_BASE}/op_ut_with_skip_test_error.log" \
-          | tee "${LOG_BASE}/op_ut_with_skip_test.log" || true
-
-        find . -name "op_ut_with_*.xml" -exec cp {} "${GITHUB_WORKSPACE}/ut_log/" \; 2>/dev/null || true
-
-        echo "Reproduce: cd $(pwd) && pytest -sv <failed_case>" \
-          | tee "${GITHUB_WORKSPACE}/ut_log/reproduce_op_ut.log"
-
-    # ── skipped_ut ──────────────────────────────────────────────────────────
-    - name: skipped_ut
-      shell: timeout 72000 bash -eo pipefail {0}
-      if: inputs.ut_name == 'skipped_ut'
-      env:
-        PYTORCH_TEST_WITH_SLOW: 1
-        LOG_BASE: ${{ github.workspace }}/ut_log/skipped_ut
-      run: |
-        [[ -n "${XPU_ONEAPI_PATH}" ]] && source "${WORKSPACE}/torch-xpu-ops/.github/scripts/env.sh" || true
-        mkdir -p "${LOG_BASE}"
-        cd "${GITHUB_WORKSPACE}/pytorch/third_party/torch-xpu-ops/test/xpu"
-
-        export PYTEST_ADDOPTS="${PYTEST_ADDOPTS//--timeout 600/--timeout 3600}"
-        python run_test_with_skip.py --test-cases skipped \
-          2> "${LOG_BASE}/skipped_ut_with_skip_test_error.log" \
-          | tee "${LOG_BASE}/skipped_ut_with_skip_test.log" || true
-
-        find . -name "op_ut_with_*.xml" -exec cp {} "${GITHUB_WORKSPACE}/ut_log/" \; 2>/dev/null || true
-
-        echo "Reproduce: cd $(pwd) && pytest -sv <failed_case>" \
-          | tee "${GITHUB_WORKSPACE}/ut_log/reproduce_skipped_ut.log"
-
-    # ── torch_xpu ───────────────────────────────────────────────────────────
-    - name: torch_xpu
-      shell: timeout 72000 bash -eo pipefail {0}
-      if: inputs.ut_name == 'torch_xpu'
-      env:
-        PYTORCH_TEST_WITH_SLOW: 1
-        PYTORCH_TESTING_DEVICE_ONLY_FOR: xpu
-        LOG_BASE: ${{ github.workspace }}/ut_log/torch_xpu
-      run: |
-        [[ -n "${XPU_ONEAPI_PATH}" ]] && source "${WORKSPACE}/torch-xpu-ops/.github/scripts/env.sh" || true
-        mkdir -p "${LOG_BASE}"
-        cd "${GITHUB_WORKSPACE}/pytorch"
-
-        # Collect all inductor + xpu test files
-        TEST_INCLUDES=""
-        for f in test/inductor/test_*.py; do
-          [[ -f "$f" ]] && TEST_INCLUDES+=" inductor/$(basename "$f")"
+          to="${TIMEOUT[$s]:-3600}"
+          echo "::group::UT suite: ${s} (timeout=${to}s)"
+          if timeout "${to}" bash "${script}"; then
+            echo "[ut] suite '${s}' completed"
+          else
+            ec=$?
+            echo "::warning::UT suite '${s}' exited with ${ec}"
+            # Per-suite scripts already best-effort with `|| true`; only a
+            # timeout (124) or genuine failure surfaces here.
+            rc=${ec}
+          fi
+          echo "::endgroup::"
         done
-        for f in test/xpu/test_*.py; do
-          [[ -f "$f" ]] && TEST_INCLUDES+=" xpu/$(basename "$f")"
-        done
-        [[ -f "test/test_xpu.py" ]] && TEST_INCLUDES+=" test_xpu.py"
-
-        python test/run_test.py --include ${TEST_INCLUDES} \
-          2> "${LOG_BASE}/torch_xpu_test_error.log" \
-          | tee "${LOG_BASE}/torch_xpu_test.log" || true
-
-    # ── xpu_profiling ───────────────────────────────────────────────────────
-    - name: xpu_profiling
-      shell: timeout 3600 bash -eo pipefail {0}
-      if: inputs.ut_name == 'xpu_profiling'
-      env:
-        LOG_BASE: ${{ github.workspace }}/ut_log/xpu_profiling
-      run: |
-        [[ -n "${XPU_ONEAPI_PATH}" ]] && source "${WORKSPACE}/torch-xpu-ops/.github/scripts/env.sh" || true
-        mkdir -p "${LOG_BASE}/issue_reproduce"
-        cd "${GITHUB_WORKSPACE}/pytorch/third_party/torch-xpu-ops"
-
-        # ResNet50 profiling
-        PROFILE=1 python -u test/profiling/rn50.py \
-          -a resnet50 --dummy ./ --num-iterations 20 --xpu 0 || true
-        cp -f profiling.fp32.train.pt "${LOG_BASE}/" 2>/dev/null || true
-
-        # Issue reproduction tests
-        for t in \
-          test/profiling/correlation_id_mixed.py \
-          test/profiling/reproducer.missing.gpu.kernel.time.py \
-          test/profiling/time_precision_in_profile.py \
-          test/profiling/profile_partial_runtime_ops.py \
-          test/profiling/triton_xpu_ops_time.py \
-          test/profiling/test_profiler_correctness.py \
-          test/profiling/test_for_overlapping_kernels.py; do
-          [[ -f "$t" ]] && python -u "$t" | tee "${LOG_BASE}/issue_reproduce/$(basename "$t" .py).log" || true
-        done
-
-        # Llama profiling
-        pip install -q transformers
-        if [[ -f "test/profiling/llama.py" ]]; then
-          python test/profiling/llama.py | tee "${LOG_BASE}/llama.log" || true
-          [[ -f ".github/scripts/llama_summary.py" ]] && \
-            python .github/scripts/llama_summary.py \
-              -i "${LOG_BASE}/llama.log" \
-              -o "${LOG_BASE}/llama_summary.csv" || true
-        fi
-
-        # Upstream profiler tests
-        cd "${GITHUB_WORKSPACE}/pytorch/test/profiler"
-        for t in test_cpp_thread.py test_execution_trace.py test_memory_profiler.py \
-                 test_profiler_tree.py test_xpu_profiler.py; do
-          [[ -f "$t" ]] && python -m pytest -s "$t" | tee "${LOG_BASE}/$(basename "$t" .py).log" || true
-        done
-
-    # ── xpu_distributed ─────────────────────────────────────────────────────
-    - name: xpu_distributed
-      shell: timeout 36000 bash -eo pipefail {0}
-      if: inputs.ut_name == 'xpu_distributed'
-      env:
-        LOG_BASE: ${{ github.workspace }}/ut_log/xpu_distributed
-      run: |
-        [[ -n "${XPU_ONEAPI_PATH}" ]] && source "${XPU_ONEAPI_PATH}/setvars.sh" || true
-        mkdir -p "${LOG_BASE}"
-
-        xpu-smi topology -m 2>/dev/null || true
-
-        cd "${GITHUB_WORKSPACE}/pytorch/third_party/torch-xpu-ops/test/xpu"
-
-        # Verify XCCL
-        XCCL=$(python -c "import torch; print(torch.distributed.is_xccl_available())" 2>/dev/null || echo False)
-        [[ "${XCCL}" == "False" ]] && { echo "::error::XCCL not available"; exit 1; }
-
-        python run_distributed.py \
-          2> "${LOG_BASE}/xpu_distributed_test_error.log" \
-          | tee "${LOG_BASE}/xpu_distributed_test.log" || true
-
-        find .. -name "*.xml" -exec cp {} "${GITHUB_WORKSPACE}/ut_log/" \; 2>/dev/null || true
-
-    # ── op_p0 ───────────────────────────────────────────────────────────────
-    - name: op_p0
-      shell: timeout 72000 bash -eo pipefail {0}
-      if: inputs.ut_name == 'op_p0'
-      env:
-        PYTORCH_TEST_WITH_SLOW: 1
-        LOG_BASE: ${{ github.workspace }}/ut_log/op_p0
-        PYTORCH_ROOT_DIR: ${{ github.workspace }}/pytorch
-        XML_OUTPUT_DIR: ${{ github.workspace }}/ut_log
-        XML_PREFIX: op_p0_with_
-      run: |
-        [[ -n "${XPU_ONEAPI_PATH}" ]] && source "${WORKSPACE}/torch-xpu-ops/.github/scripts/env.sh" || true
-        mkdir -p "${LOG_BASE}"
-        cd "${GITHUB_WORKSPACE}/pytorch/"
-
-        "${GITHUB_WORKSPACE}/.ci/benchmarks/p0/run_ut.sh" \
-          2> "${LOG_BASE}/op_p0_with_skip_test_error.log" \
-          | tee "${LOG_BASE}/op_p0_with_skip_test.log" || true
-
-        find . -name "op_p0_with_*.xml" -exec cp {} "${GITHUB_WORKSPACE}/ut_log/" \; 2>/dev/null || true
-
-        echo "Reproduce: cd $(pwd) && pytest -sv <failed_case>" \
-          | tee "${GITHUB_WORKSPACE}/ut_log/reproduce_op_p0.log"
+        exit "${rc}"

--- a/.github/actions/summarize-ut/action.yml
+++ b/.github/actions/summarize-ut/action.yml
@@ -1,0 +1,161 @@
+name: Summarize UT results
+description: >-
+  Scan ut_log/ for JUnit XML files, classify cases, and emit a step summary
+  with per-suite counts plus a collapsed list of failing tests. Best-effort:
+  parsing errors do not fail the step.
+
+inputs:
+  log-dir:
+    required: false
+    default: ${{ github.workspace }}/ut_log
+    description: Directory containing JUnit XML files (and *_test_error.log).
+  fail-on-failure:
+    required: false
+    default: 'false'
+    description: If 'true', set the step exit code to 1 when any test failed.
+
+outputs:
+  total:
+    value: ${{ steps.scan.outputs.total }}
+  passed:
+    value: ${{ steps.scan.outputs.passed }}
+  failed:
+    value: ${{ steps.scan.outputs.failed }}
+  errored:
+    value: ${{ steps.scan.outputs.errored }}
+  skipped:
+    value: ${{ steps.scan.outputs.skipped }}
+
+runs:
+  using: composite
+  steps:
+    - name: Scan JUnit XMLs
+      id: scan
+      shell: bash -eo pipefail {0}
+      env:
+        LOG_DIR: ${{ inputs.log-dir }}
+        FAIL_ON_FAILURE: ${{ inputs.fail-on-failure }}
+      run: |
+        python3 - <<'PY'
+        import os
+        import sys
+        import glob
+        import xml.etree.ElementTree as ET
+        from collections import defaultdict
+
+        log_dir = os.environ.get("LOG_DIR", "")
+        fail_on = os.environ.get("FAIL_ON_FAILURE", "false").lower() == "true"
+        summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+        out_path = os.environ.get("GITHUB_OUTPUT")
+
+        totals = defaultdict(int)        # global tallies
+        per_suite = defaultdict(lambda: defaultdict(int))
+        failures = []                    # list of (suite, classname, name, kind, message)
+
+        if not log_dir or not os.path.isdir(log_dir):
+            print(f"[summarize-ut] no log dir: {log_dir!r} - nothing to do")
+            xmls = []
+        else:
+            xmls = sorted(glob.glob(os.path.join(log_dir, "**", "*.xml"), recursive=True))
+
+        for path in xmls:
+            suite = os.path.splitext(os.path.basename(path))[0]
+            try:
+                tree = ET.parse(path)
+            except ET.ParseError as e:
+                print(f"::warning::skipping malformed XML {path}: {e}")
+                continue
+            root = tree.getroot()
+            # Handle both <testsuite> and <testsuites> roots.
+            testsuites = [root] if root.tag == "testsuite" else list(root.iter("testsuite"))
+            for ts in testsuites:
+                for tc in ts.iter("testcase"):
+                    totals["total"] += 1
+                    per_suite[suite]["total"] += 1
+                    failed = tc.find("failure")
+                    errored = tc.find("error")
+                    skipped = tc.find("skipped")
+                    if failed is not None:
+                        kind = "failure"
+                    elif errored is not None:
+                        kind = "error"
+                    elif skipped is not None:
+                        kind = "skipped"
+                    else:
+                        kind = "passed"
+                    totals[kind] = totals.get(kind, 0) + 1
+                    per_suite[suite][kind] = per_suite[suite].get(kind, 0) + 1
+                    if kind in ("failure", "error"):
+                        node = failed if kind == "failure" else errored
+                        msg = (node.get("message") or "").splitlines()[0][:200] if node is not None else ""
+                        failures.append((
+                            suite,
+                            tc.get("classname", ""),
+                            tc.get("name", ""),
+                            kind,
+                            msg,
+                        ))
+
+        passed = totals["total"] - sum(totals.get(k, 0) for k in ("failure", "error", "skipped"))
+        totals["passed"] = passed
+
+        # ---- step summary ----
+        lines = ["## Unit Test Summary", ""]
+        if not xmls:
+            lines.append("_No JUnit XML files found in_ `" + log_dir + "`.")
+        else:
+            lines.append(
+                f"**Total:** {totals['total']} &nbsp; "
+                f"**Passed:** {passed} &nbsp; "
+                f"**Failed:** {totals.get('failure', 0)} &nbsp; "
+                f"**Errored:** {totals.get('error', 0)} &nbsp; "
+                f"**Skipped:** {totals.get('skipped', 0)}"
+            )
+            lines.append("")
+            lines.append("| Suite | Total | Passed | Failed | Errored | Skipped |")
+            lines.append("|---|---:|---:|---:|---:|---:|")
+            for suite in sorted(per_suite):
+                c = per_suite[suite]
+                p = c["total"] - c.get("failure", 0) - c.get("error", 0) - c.get("skipped", 0)
+                lines.append(
+                    f"| `{suite}` | {c['total']} | {p} | "
+                    f"{c.get('failure', 0)} | {c.get('error', 0)} | {c.get('skipped', 0)} |"
+                )
+
+            if failures:
+                lines += ["", "<details><summary>Failed tests (first 200)</summary>", ""]
+                lines.append("| Suite | Class | Test | Kind | Message |")
+                lines.append("|---|---|---|---|---|")
+                for suite, cls, name, kind, msg in failures[:200]:
+                    safe_msg = msg.replace("|", "\\|")
+                    lines.append(f"| `{suite}` | `{cls}` | `{name}` | {kind} | {safe_msg} |")
+                if len(failures) > 200:
+                    lines.append("")
+                    lines.append(f"_... and {len(failures) - 200} more_")
+                lines += ["", "</details>"]
+
+        body = "\n".join(lines) + "\n"
+        if summary_path:
+            with open(summary_path, "a", encoding="utf-8") as fh:
+                fh.write(body)
+
+        # ut-summary.md artifact next to the logs
+        try:
+            os.makedirs(log_dir, exist_ok=True)
+            with open(os.path.join(log_dir, "ut-summary.md"), "w", encoding="utf-8") as fh:
+                fh.write(body)
+        except OSError as e:
+            print(f"::warning::could not write ut-summary.md: {e}")
+
+        # ---- outputs ----
+        if out_path:
+            with open(out_path, "a", encoding="utf-8") as fh:
+                fh.write(f"total={totals['total']}\n")
+                fh.write(f"passed={passed}\n")
+                fh.write(f"failed={totals.get('failure', 0)}\n")
+                fh.write(f"errored={totals.get('error', 0)}\n")
+                fh.write(f"skipped={totals.get('skipped', 0)}\n")
+
+        if fail_on and (totals.get("failure", 0) + totals.get("error", 0)) > 0:
+            sys.exit(1)
+        PY

--- a/.github/workflows/_linux_ut.yml
+++ b/.github/workflows/_linux_ut.yml
@@ -10,7 +10,7 @@ on:
       docker_image_name:
         type: string
         default: 'intelgpu/ubuntu-24.04-lts2:2523.40'
-        description: Docker image for test environment
+        description: Docker image for test environment (UT job only)
       pytorch:
         type: string
         default: main
@@ -28,7 +28,7 @@ on:
         required: true
         description: >-
           UT scope: op_regression, op_regression_dev1, op_extended,
-          op_ut, skipped_ut, torch_xpu, basic, xpu_distributed, xpu_profiling
+          op_ut, skipped_ut, torch_xpu, basic, xpu_distributed, xpu_profiling, op_p0
       category:
         type: string
         default: default
@@ -59,7 +59,7 @@ env:
   WORKSPACE: ${{ github.workspace }}
 
 jobs:
-  # Resolve runner
+  # ── Resolve runner ────────────────────────────────────────────────────────
   runner:
     name: get-runner
     runs-on: ${{ inputs.runner }}
@@ -83,7 +83,7 @@ jobs:
         id: runner-info
         uses: ./.github/actions/get-runner
 
-  # Unit tests (container)
+  # ── Unit tests (containerised) ────────────────────────────────────────────
   UT:
     name: ${{ inputs.ut }}
     needs: runner
@@ -138,6 +138,12 @@ jobs:
         with:
           ut_name: ${{ inputs.ut }}
 
+      - name: Summarize results
+        if: ${{ ! cancelled() }}
+        uses: ./.github/actions/summarize-ut
+        with:
+          log-dir: ${{ github.workspace }}/ut_log
+
       - name: Collect UT logs
         id: collect-logs
         if: ${{ ! cancelled() }}
@@ -157,8 +163,9 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
-  # Distributed tests (baremetal)
+  # ── Distributed tests (baremetal, no container) ───────────────────────────
   distributed:
+    name: ${{ inputs.ut }}
     needs: runner
     if: contains(inputs.ut, 'distributed')
     runs-on: ${{ needs.runner.outputs.runner_id }}
@@ -194,6 +201,12 @@ jobs:
         uses: ./.github/actions/linux-uttest
         with:
           ut_name: ${{ inputs.ut }}
+
+      - name: Summarize results
+        if: ${{ ! cancelled() }}
+        uses: ./.github/actions/summarize-ut
+        with:
+          log-dir: ${{ github.workspace }}/ut_log
 
       - name: Collect UT logs
         id: collect-logs


### PR DESCRIPTION
## Summary

Fourth PR in the CI/CD refactor series. Splits the monolithic `linux-uttest` composite action into per-suite scripts and adds a structured UT summary that surfaces failing tests in the GitHub job UI.

> **Stacked on:** #13 - Refactor E2E (#13 -> #12 -> #11). Review/merge those first.

## Why

`linux-uttest/action.yml` was 243 lines of 9 nearly-identical `if inputs.ut_name == X` blocks - each inlining its own bash. Per-suite logic was impossible to read, hard to test in isolation, and not reusable outside the action.

## Changes

### New per-suite scripts

```
.ci/scripts/ut/
  _lib.sh                  shared helpers (oneAPI sourcing, log-dir, reproduce-line)
  op_regression.sh
  op_regression_dev1.sh
  op_extended.sh
  op_ut.sh
  skipped_ut.sh
  torch_xpu.sh
  xpu_profiling.sh
  xpu_distributed.sh
  op_p0.sh
```

Each script preserves the exact behavior of the corresponding inline block.

### Refactored action

`linux-uttest` is now ~75 lines (was 243): it looks up the per-suite timeout from a single `declare -A` map, expands `basic` -> `{op_regression, op_regression_dev1, op_extended}`, and dispatches to the matching script under `$SCRIPTS_DIR`.

### New action

`summarize-ut` scans `ut_log/` for JUnit XML, classifies each `<testcase>`, and emits:
- a one-line totals header,
- a per-suite counts table (Total / Passed / Failed / Errored / Skipped),
- a collapsed *Failed tests* table (first 200) with class/test/kind/message,

to `$GITHUB_STEP_SUMMARY`. Also writes `ut-summary.md` alongside the logs and exposes `total/passed/failed/errored/skipped` as step outputs. Best-effort: parsing errors do not fail the step.

### Workflow

`_linux_ut.yml`: the UT and distributed jobs each get a `Summarize results` step before artifact collection. No change to inputs, container config, or artifact naming.

## Behavior

- All suite logic is byte-equivalent to the previous inline form (same commands, same `|| true`, same per-suite timeouts: 300/3600/36000/72000s).
- `basic` keeps its meaning (`op_regression + op_regression_dev1 + op_extended`).
- New: failing tests appear in a collapsed table in the GitHub job summary - no need to download artifacts to find regressions.

Net: 13 files changed.

## Roadmap

- PR 1: code check (#11)
- PR 2: build (#12)
- PR 3: dynamo benchmark / E2E (#13)
- **PR 4: unit tests (this)**
- Next: distributed (Windows parity), microbench, accelerate, transformers, unified reporting.
