### PR TITLE
Refactor distributed tests: dedicated reusable workflow

### DIFF
--- a/.github/workflows/_linux_distributed.yml
+++ b/.github/workflows/_linux_distributed.yml
@@ -1,4 +1,4 @@
-name: Linux UT Test
+name: Linux Distributed Test
 
 on:
   workflow_call:
@@ -6,11 +6,7 @@ on:
       runner:
         type: string
         required: true
-        description: Runner label for test execution
-      docker_image_name:
-        type: string
-        default: 'intelgpu/ubuntu-24.04-lts2:2523.40'
-        description: Docker image for test environment (UT job only)
+        description: Runner label for distributed test execution
       pytorch:
         type: string
         default: main
@@ -25,11 +21,8 @@ on:
         description: Python version
       ut:
         type: string
-        required: true
-        description: >-
-          UT scope: op_regression, op_regression_dev1, op_extended,
-          op_ut, skipped_ut, torch_xpu, basic, xpu_profiling, op_p0.
-          Note: xpu_distributed runs in _linux_distributed.yml.
+        default: xpu_distributed
+        description: Distributed UT scope (xpu_distributed)
       category:
         type: string
         default: default
@@ -66,10 +59,6 @@ jobs:
     runs-on: ${{ inputs.runner }}
     outputs:
       runner_id: ${{ steps.runner-info.outputs.runner_id }}
-      user_id: ${{ steps.runner-info.outputs.user_id }}
-      render_id: ${{ steps.runner-info.outputs.render_id }}
-      hostname: ${{ steps.runner-info.outputs.hostname }}
-      pytest_extra_args: ${{ steps.runner-info.outputs.pytest_extra_args }}
       ze_affinity_mask: ${{ steps.runner-info.outputs.ZE_AFFINITY_MASK }}
     steps:
       - name: Clean workspace
@@ -84,38 +73,22 @@ jobs:
         id: runner-info
         uses: ./.github/actions/get-runner
 
-  # ── Unit tests (containerised) ────────────────────────────────────────────
-  UT:
+  # ── Distributed tests (baremetal, no container) ───────────────────────────
+  distributed:
     name: ${{ inputs.ut }}
     needs: runner
     runs-on: ${{ needs.runner.outputs.runner_id }}
-    timeout-minutes: 1440
-    container:
-      image: ${{ inputs.docker_image_name }}
-      volumes:
-        - ${{ github.workspace }}:${{ github.workspace }}
-        - /opt/xpu-test/.cache:/github/home/.cache
-      options: >-
-        --rm
-        --device=/dev/mem
-        --device=/dev/dri
-        --group-add video
-        --security-opt seccomp=unconfined
-        --cap-add=SYS_PTRACE
-        --shm-size=8g
-        -u ${{ needs.runner.outputs.user_id }}:${{ needs.runner.outputs.render_id }}
-      env:
-        AGENT_TOOLSDIRECTORY: /tmp/xpu-tool
-        WORKSPACE: ${{ github.workspace }}
-        ZE_AFFINITY_MASK: ${{ needs.runner.outputs.ze_affinity_mask }}
-        PYTHONPATH: ${{ github.workspace }}/.github
-        PYTEST_ADDOPTS: >-
-          -sq -q --tb=short -p scripts.conftest
-          --timeout 600 --timeout_method=thread
-          --max-worker-restart 1000000
-          --dist worksteal
-          --only-rerun 'crashed while running' --reruns 2
-          ${{ needs.runner.outputs.pytest_extra_args }}
+    timeout-minutes: 600
+    env:
+      AGENT_TOOLSDIRECTORY: /tmp/xpu-tool
+      WORKSPACE: ${{ github.workspace }}
+      ZE_AFFINITY_MASK: ${{ needs.runner.outputs.ze_affinity_mask }}
+      PYTHONPATH: ${{ github.workspace }}/.github
+      PYTEST_ADDOPTS: >-
+        -sq -q --tb=short -p scripts.conftest
+        --timeout 3600 --timeout_method=thread
+        -n 1
+        --max-worker-restart 10000
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -128,12 +101,12 @@ jobs:
           pytorch: ${{ inputs.pytorch }}
           torch_xpu_ops: ${{ inputs.torch_xpu_ops }}
           python: ${{ inputs.python }}
-          suite: ${{ contains(inputs.ut, 'transformers') && 'huggingface' || 'None' }}
+          suite: None
           component: ${{ inputs.component }}
           component_version: ${{ inputs.component_version }}
           category: ${{ inputs.category }}
 
-      - name: Run unit tests
+      - name: Run distributed tests
         uses: ./.github/actions/linux-uttest
         with:
           ut_name: ${{ inputs.ut }}
@@ -149,7 +122,7 @@ jobs:
         if: ${{ ! cancelled() }}
         run: |
           if [ ! -d "${WORKSPACE}/ut_log" ]; then
-            echo "::warning::No UT logs found"
+            echo "::warning::No distributed UT logs found"
             exit 0
           fi
           echo "Collected $(find "${WORKSPACE}/ut_log" -type f | wc -l) log files"
@@ -162,4 +135,3 @@ jobs:
           path: ${{ github.workspace }}/ut_log
           retention-days: 7
           if-no-files-found: ignore
-

--- a/.github/workflows/_test_call.yml
+++ b/.github/workflows/_test_call.yml
@@ -85,14 +85,15 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
-      ut_json:  ${{ steps.matrix.outputs.ut_json }}
-      e2e_json: ${{ steps.matrix.outputs.e2e_json }}
+      ut_json:           ${{ steps.matrix.outputs.ut_json }}
+      e2e_json:          ${{ steps.matrix.outputs.e2e_json }}
+      distributed_json:  ${{ steps.matrix.outputs.distributed_json }}
     steps:
       - name: Build matrix JSON arrays
         id: matrix
         run: |
           csv_to_json() {
-            local input="$1"
+            local input="$1" filter_distributed="${2:-keep}"
             if [ -z "$input" ]; then
               echo "[]"
               return
@@ -103,6 +104,9 @@ jobs:
               x="${x#"${x%%[![:space:]]*}"}"   # trim leading
               x="${x%"${x##*[![:space:]]}"}"   # trim trailing
               [[ "$x" == "windows" || "$x" == "microbench" || -z "$x" ]] && continue
+              # distributed suites are dispatched to _linux_distributed.yml
+              if [[ "$filter_distributed" == "drop" && "$x" == *distributed* ]]; then continue; fi
+              if [[ "$filter_distributed" == "only" && "$x" != *distributed* ]]; then continue; fi
               json+="${sep}\"${x}\""
               sep=","
             done
@@ -110,11 +114,13 @@ jobs:
             echo "$json"
           }
 
-          ut_json="$(csv_to_json "${{ inputs.ut }}")"
+          ut_json="$(csv_to_json "${{ inputs.ut }}" drop)"
+          distributed_json="$(csv_to_json "${{ inputs.ut }}" only)"
           e2e_json="$(csv_to_json "${{ inputs.suite }}")"
 
-          echo "ut_json=${ut_json}"   >> "$GITHUB_OUTPUT"
-          echo "e2e_json=${e2e_json}" >> "$GITHUB_OUTPUT"
+          echo "ut_json=${ut_json}"                   >> "$GITHUB_OUTPUT"
+          echo "distributed_json=${distributed_json}" >> "$GITHUB_OUTPUT"
+          echo "e2e_json=${e2e_json}"                 >> "$GITHUB_OUTPUT"
 
   # Build
   linux-build:
@@ -142,6 +148,26 @@ jobs:
       matrix:
         ut_name: ${{ fromJSON(needs.tests-matrix.outputs.ut_json) }}
     uses: ./.github/workflows/_linux_ut.yml
+    with:
+      runner: ${{ inputs.runner }}
+      pytorch: ${{ inputs.pytorch }}
+      torch_xpu_ops: ${{ inputs.torch_xpu_ops }}
+      python: ${{ inputs.python }}
+      ut: ${{ matrix.ut_name }}
+      category: ${{ inputs.category }}
+      component: ${{ inputs.component }}
+      component_version: ${{ inputs.component_version }}
+
+  # Linux Distributed Tests (baremetal, separate workflow)
+  linux-distributed:
+    needs: [linux-build, tests-matrix]
+    if: needs.tests-matrix.outputs.distributed_json != '[]'
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        ut_name: ${{ fromJSON(needs.tests-matrix.outputs.distributed_json) }}
+    uses: ./.github/workflows/_linux_distributed.yml
     with:
       runner: ${{ inputs.runner }}
       pytorch: ${{ inputs.pytorch }}


### PR DESCRIPTION
## Summary

Fifth PR in the CI/CD refactor series. Lifts distributed tests out of `_linux_ut.yml` into a dedicated reusable workflow.

> **Stacked on:** #14 - Refactor UT (#14 -> #13 -> #12 -> #11). Review/merge those first.

## Why

Distributed tests share almost nothing with containerised UT runs:

|  | Containerised UT | Distributed |
|---|---|---|
| Runtime | Docker container | Baremetal |
| Concurrency | pytest-xdist (n>=1) | single-process (`-n 1`) |
| Per-test timeout | 600 s | 3600 s |
| Setup | docker volumes, render group | direct host filesystem |
| Driver | `run_test_with_skip.py` | `run_distributed.py` |

In the previous layout `_linux_ut.yml` had two jobs gated by `if: contains(inputs.ut, 'distributed')`, and `_test_call.yml` pretended `xpu_distributed` was just another UT name. That made both files dual-purpose and obscured the distinct lifecycles.

## Changes

### New workflow

```
.github/workflows/_linux_distributed.yml      reusable workflow: runner job
                                              + baremetal distributed job
```

Reuses the existing `get-runner`, `linux-testenv`, `linux-uttest` (which dispatches `xpu_distributed.sh`), and `summarize-ut` actions, so behavior is byte-equivalent to the previous distributed job.

### Slimmed `_linux_ut.yml`

- Drop the `distributed` job (76 lines).
- Drop the `if: ${{ ! contains(inputs.ut, 'distributed') }}` gating on the `UT` job - it no longer has a sibling.
- Update the `ut` input docstring to remove `xpu_distributed`.

215 -> 165 lines.

### Updated dispatcher `_test_call.yml`

- `csv_to_json()` gains a `filter_distributed` argument:
  - `drop`: omit any token matching `*distributed*` (used for `ut_json`)
  - `only`: keep only tokens matching `*distributed*` (used for `distributed_json`)
  - `keep` (default): unchanged
- New `linux-distributed` matrix dispatch calling `_linux_distributed.yml`.

## Surface compatibility

- No change for callers. `pull.yml`, `nightly_ondemand.yml`, etc. still emit the same comma-separated `ut` list including `xpu_distributed`; the dispatcher routes it.
- Artifact name unchanged (`Inductor-XPU-UT-Data-...`).

Net: 3 files changed, **+171 / -71**.

## Roadmap

- PR 1: code check (#11)
- PR 2: build (#12)
- PR 3: dynamo benchmark / E2E (#13)
- PR 4: unit tests (#14)
- **PR 5: distributed tests (this)**
- Next: microbench, accelerate, transformers, Windows UT parity, unified reporting.
