### PR TITLE
Refactor microbench: extracted scripts + composite actions

### DIFF
--- a/.ci/scripts/microbench/compare.sh
+++ b/.ci/scripts/microbench/compare.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Compare current microbench summary CSVs against the staged baseline,
+# then update the baseline (best-of) for the next run. Skipped silently
+# when the baseline is missing (first-ever run).
+
+set -euo pipefail
+
+: "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}"
+SCRIPTS="${GITHUB_WORKSPACE}/.github/scripts"
+WS="${GITHUB_WORKSPACE}"
+
+pip install --quiet tabulate pandas
+
+if [[ ! -f "${WS}/baseline/baseline_forward_op_summary.csv" ]]; then
+    echo "::notice::no baseline staged - skipping comparison"
+    exit 0
+fi
+
+echo "::group::Forward op regression check"
+python "${SCRIPTS}/op_perf_comparison.py" \
+    --xpu_file      "${WS}/op_benchmark/forward_op_summary.csv" \
+    --baseline_file "${WS}/baseline/baseline_forward_op_summary.csv"
+echo "::endgroup::"
+
+echo "::group::Backward op regression check"
+python "${SCRIPTS}/op_perf_comparison.py" \
+    --xpu_file      "${WS}/op_benchmark/backward_op_summary.csv" \
+    --baseline_file "${WS}/baseline/baseline_backward_op_summary.csv"
+echo "::endgroup::"
+
+# Update best-of baseline for the next run.
+mkdir -p "${WS}/new_baseline"
+cp "${WS}/baseline/"baseline*.csv "${WS}/new_baseline/"
+
+python "${SCRIPTS}/op_calculate_best_perf.py" \
+    --xpu      "${WS}/op_benchmark/forward_op_summary.csv" \
+    --baseline "${WS}/new_baseline/baseline_forward_op_summary.csv" -r
+python "${SCRIPTS}/op_calculate_best_perf.py" \
+    --xpu      "${WS}/op_benchmark/backward_op_summary.csv" \
+    --baseline "${WS}/new_baseline/baseline_backward_op_summary.csv" -r
+
+cp -r "${WS}/new_baseline" "${WS}/op_benchmark/"

--- a/.ci/scripts/microbench/fetch_baseline.sh
+++ b/.ci/scripts/microbench/fetch_baseline.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Download the previous microbench baseline artifact from the reference
+# issue and stage it under $GITHUB_WORKSPACE/baseline. Tolerates missing
+# baseline (first-ever run): emits a warning and exits 0 with no files.
+#
+# Inputs (env):
+#   GH_TOKEN          GitHub token with issues:read permission
+#   GITHUB_REPOSITORY  owner/repo
+#   REFERENCE_ISSUE   issue number whose body has "Inductor-XPU-OP-Benchmark-Data: <run_id>"
+#   ARTIFACT_DIR      where the upstream artifact was downloaded
+#                     (default: $GITHUB_WORKSPACE/op_benchmark_tmp)
+#   CURRENT_PREFIX    the current run's artifact prefix (we lift it out of ARTIFACT_DIR)
+
+set -euo pipefail
+
+: "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}"
+: "${REFERENCE_ISSUE:?REFERENCE_ISSUE is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+ARTIFACT_DIR="${ARTIFACT_DIR:-${GITHUB_WORKSPACE}/op_benchmark_tmp}"
+CURRENT_PREFIX="${CURRENT_PREFIX:-Inductor-XPU-OP-Benchmark-Data}"
+
+# 1. Move the current-run artifact into op_benchmark/.
+latest_dir=$(find "${ARTIFACT_DIR}" -maxdepth 1 -type d \
+    -name "${CURRENT_PREFIX}-*" 2>/dev/null | sort -V | tail -n 1 || true)
+if [[ -n "${latest_dir}" ]]; then
+    mkdir -p "${GITHUB_WORKSPACE}/op_benchmark"
+    mv "${latest_dir}"/* "${GITHUB_WORKSPACE}/op_benchmark/" 2>/dev/null || true
+fi
+
+# 2. Resolve the baseline run id from the reference issue body.
+ref_run_id=$(gh --repo "${GITHUB_REPOSITORY}" issue view "${REFERENCE_ISSUE}" \
+    --json body -q .body 2>/dev/null \
+    | grep "Inductor-XPU-OP-Benchmark-Data" \
+    | sed 's/.*: *//' \
+    | head -n 1 || true)
+
+mkdir -p "${GITHUB_WORKSPACE}/baseline"
+if [[ -z "${ref_run_id}" ]]; then
+    echo "::warning::no baseline run id in issue #${REFERENCE_ISSUE}; skipping comparison"
+    exit 0
+fi
+
+# 3. Download the baseline run's artifacts.
+work=$(mktemp -d)
+pushd "${work}" >/dev/null
+if ! gh --repo "${GITHUB_REPOSITORY}" run download "${ref_run_id}" \
+        -p "Inductor-XPU-OP-Benchmark-Data-*" 2>/dev/null; then
+    echo "::warning::failed to download baseline run ${ref_run_id}; skipping comparison"
+    popd >/dev/null
+    exit 0
+fi
+mkdir -p "${GITHUB_WORKSPACE}/reference"
+shopt -s nullglob
+matches=( Inductor-XPU-OP-Benchmark-Data-*-Updated )
+shopt -u nullglob
+if (( ${#matches[@]} > 0 )); then
+    mv -f "${matches[0]}"/* "${GITHUB_WORKSPACE}/reference/"
+else
+    # Fall back: any matching dir.
+    shopt -s nullglob
+    any=( Inductor-XPU-OP-Benchmark-Data-* )
+    shopt -u nullglob
+    [[ ${#any[@]} -gt 0 ]] && mv -f "${any[0]}"/* "${GITHUB_WORKSPACE}/reference/"
+fi
+popd >/dev/null
+
+# 4. Stage baseline_*.csv under baseline/.
+ref="${GITHUB_WORKSPACE}/reference"
+if [[ -f "${ref}/new_baseline/baseline_forward_op_summary.csv" ]]; then
+    cp "${ref}/new_baseline/baseline_forward_op_summary.csv"  "${GITHUB_WORKSPACE}/baseline/"
+    cp "${ref}/new_baseline/baseline_backward_op_summary.csv" "${GITHUB_WORKSPACE}/baseline/"
+elif [[ -f "${ref}/forward_op_summary.csv" ]]; then
+    cp "${ref}/forward_op_summary.csv"  "${GITHUB_WORKSPACE}/baseline/baseline_forward_op_summary.csv"
+    cp "${ref}/backward_op_summary.csv" "${GITHUB_WORKSPACE}/baseline/baseline_backward_op_summary.csv"
+else
+    echo "::warning::no baseline summary CSV found in downloaded reference"
+fi

--- a/.ci/scripts/microbench/run.sh
+++ b/.ci/scripts/microbench/run.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Run all microbenchmarks under pytorch/test/microbench and emit
+# forward/backward summary CSVs.
+#
+# Inputs (env):
+#   PYTORCH_DIR     pytorch source dir (default: $GITHUB_WORKSPACE/pytorch)
+#   OUT_DIR         output dir for raw logs and summary CSVs
+#                   (default: $GITHUB_WORKSPACE/op_benchmark)
+#   SUMMARY_SCRIPT  path to microbench_summary.py
+#                   (default: $GITHUB_WORKSPACE/.github/scripts/microbench_summary.py)
+
+set -euo pipefail
+
+: "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}"
+PYTORCH_DIR="${PYTORCH_DIR:-${GITHUB_WORKSPACE}/pytorch}"
+OUT_DIR="${OUT_DIR:-${GITHUB_WORKSPACE}/op_benchmark}"
+SUMMARY_SCRIPT="${SUMMARY_SCRIPT:-${GITHUB_WORKSPACE}/.github/scripts/microbench_summary.py}"
+
+mkdir -p "${OUT_DIR}"
+
+bench_dir="${PYTORCH_DIR}/test/microbench"
+[[ -d "${bench_dir}" ]] || bench_dir="test/microbench"
+cd "${bench_dir}"
+
+shopt -s nullglob
+files=( *.py )
+shopt -u nullglob
+if (( ${#files[@]} == 0 )); then
+    echo "::error::no microbench scripts under ${bench_dir}"
+    exit 1
+fi
+
+echo "::group::Running ${#files[@]} microbench scripts"
+for f in "${files[@]}"; do
+    name="${f%.py}"
+    echo "[microbench] ${name}"
+    python "${f}" > "${OUT_DIR}/${name}.log" || \
+        echo "::warning::microbench ${name} failed (continuing)"
+done
+echo "::endgroup::"
+
+pip install --quiet pandas openpyxl
+
+python "${SUMMARY_SCRIPT}" "${OUT_DIR}" "${OUT_DIR}/forward_op_summary.csv"
+python "${SUMMARY_SCRIPT}" "${OUT_DIR}" "${OUT_DIR}/backward_op_summary.csv" --backward

--- a/.ci/scripts/microbench/update_reference_issue.sh
+++ b/.ci/scripts/microbench/update_reference_issue.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Update the reference issue body so the next run picks up this run as
+# its baseline. Best-effort: writes a warning and exits 0 on failure.
+
+set -euo pipefail
+
+: "${REFERENCE_ISSUE:?REFERENCE_ISSUE is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+: "${GITHUB_RUN_ID:?GITHUB_RUN_ID is required}"
+
+body=$(gh --repo "${GITHUB_REPOSITORY}" issue view "${REFERENCE_ISSUE}" \
+    --json body -q .body 2>/dev/null || true)
+if [[ -z "${body}" ]]; then
+    echo "::warning::could not read issue #${REFERENCE_ISSUE}; skipping update"
+    exit 0
+fi
+
+new_body=$(printf '%s\n' "${body}" \
+    | sed "s/Inductor-XPU-OP-Benchmark-Data:.*/Inductor-XPU-OP-Benchmark-Data: ${GITHUB_RUN_ID}/" \
+    | sed '/^$/d')
+
+tmp=$(mktemp)
+printf '%s\n' "${new_body}" > "${tmp}"
+trap 'rm -f "${tmp}"' EXIT
+
+if ! gh --repo "${GITHUB_REPOSITORY}" issue edit "${REFERENCE_ISSUE}" --body-file "${tmp}"; then
+    echo "::warning::failed to update reference issue #${REFERENCE_ISSUE}"
+fi

--- a/.github/actions/compare-microbench/action.yml
+++ b/.github/actions/compare-microbench/action.yml
@@ -1,0 +1,56 @@
+name: Compare microbench against baseline
+description: >-
+  Download the microbench baseline artifact referenced from the issue
+  body, compare current vs baseline, then update the best-of baseline
+  for the next run. Tolerates missing baseline (first-ever run).
+
+inputs:
+  reference-issue:
+    required: true
+    description: GitHub issue number whose body holds the baseline run id.
+  artifact-dir:
+    required: false
+    default: ${{ github.workspace }}/op_benchmark_tmp
+    description: Where the upstream artifact was downloaded to.
+  current-prefix:
+    required: false
+    default: Inductor-XPU-OP-Benchmark-Data
+    description: Artifact name prefix for the current run.
+  scripts-dir:
+    required: false
+    default: ${{ github.workspace }}/.ci/scripts/microbench
+    description: Directory containing fetch_baseline.sh / compare.sh / update_reference_issue.sh.
+  github-token:
+    required: true
+    description: Token with issues:read+write to manage the reference issue.
+  update-reference-issue:
+    required: false
+    default: 'true'
+    description: When 'true', overwrite the reference issue body with this run id.
+
+runs:
+  using: composite
+  steps:
+    - name: Fetch baseline
+      shell: bash -eo pipefail {0}
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REFERENCE_ISSUE: ${{ inputs.reference-issue }}
+        ARTIFACT_DIR: ${{ inputs.artifact-dir }}
+        CURRENT_PREFIX: ${{ inputs.current-prefix }}
+      run: |
+        bash "${{ inputs.scripts-dir }}/fetch_baseline.sh"
+
+    - name: Compare and update best-of baseline
+      shell: bash -eo pipefail {0}
+      run: |
+        bash "${{ inputs.scripts-dir }}/compare.sh"
+
+    - name: Update reference issue
+      if: ${{ inputs.update-reference-issue == 'true' }}
+      shell: bash -eo pipefail {0}
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REFERENCE_ISSUE: ${{ inputs.reference-issue }}
+      run: |
+        bash "${{ inputs.scripts-dir }}/update_reference_issue.sh"

--- a/.github/actions/run-microbench/action.yml
+++ b/.github/actions/run-microbench/action.yml
@@ -1,0 +1,29 @@
+name: Run microbenchmarks
+description: >-
+  Execute every script under pytorch/test/microbench and emit
+  forward/backward summary CSVs to op_benchmark/.
+
+inputs:
+  out-dir:
+    required: false
+    default: ${{ github.workspace }}/op_benchmark
+    description: Output directory for raw logs and summary CSVs.
+  pytorch-dir:
+    required: false
+    default: ${{ github.workspace }}/pytorch
+    description: PyTorch source directory.
+  scripts-dir:
+    required: false
+    default: ${{ github.workspace }}/.ci/scripts/microbench
+    description: Directory containing run.sh.
+
+runs:
+  using: composite
+  steps:
+    - name: Run microbench suite
+      shell: bash -eo pipefail {0}
+      env:
+        OUT_DIR: ${{ inputs.out-dir }}
+        PYTORCH_DIR: ${{ inputs.pytorch-dir }}
+      run: |
+        bash "${{ inputs.scripts-dir }}/run.sh"

--- a/.github/workflows/_linux_op_benchmark.yml
+++ b/.github/workflows/_linux_op_benchmark.yml
@@ -16,6 +16,14 @@ on:
         type: string
         default: '3.10'
         description: Python version
+      reference_issue:
+        type: string
+        default: '1689'
+        description: GitHub issue number whose body holds the microbench baseline run id.
+      docker_image_name:
+        type: string
+        default: 'intelgpu/ubuntu-24.04-lts2:2523.40'
+        description: Docker image for the benchmark container.
 
 permissions:
   contents: read
@@ -23,22 +31,23 @@ permissions:
 defaults:
   run:
     shell: bash -xe {0}
+
 env:
   GH_TOKEN: ${{ github.token }}
   HF_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
   HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
   DOCKER_REGISTRY_AUTH_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
-  reference_issue: 1689
 
 jobs:
+  # ── Resolve runner ────────────────────────────────────────────────────────
   runner:
     runs-on: ${{ inputs.runner }}
     name: get-runner
     outputs:
       runner_id: ${{ steps.runner-info.outputs.runner_id }}
-      user_id: ${{ steps.runner-info.outputs.user_id }}
+      user_id:   ${{ steps.runner-info.outputs.user_id }}
       render_id: ${{ steps.runner-info.outputs.render_id }}
-      hostname: ${{ steps.runner-info.outputs.hostname }}
+      hostname:  ${{ steps.runner-info.outputs.hostname }}
     steps:
       - name: Clean workspace
         run: sudo find . -maxdepth 1 ! -name '.' ! -name '..' -exec sudo rm -rf {} + 2>/dev/null || true
@@ -48,47 +57,47 @@ jobs:
         id: runner-info
         uses: ./.github/actions/get-runner
 
+  # ── Run microbench ────────────────────────────────────────────────────────
   op_benchmark:
     needs: runner
     runs-on: ${{ needs.runner.outputs.runner_id }}
     timeout-minutes: 900
     container:
-      image: intelgpu/ubuntu-24.04-lts2:2523.40
+      image: ${{ inputs.docker_image_name }}
       volumes:
         - ${{ github.workspace }}:${{ github.workspace }}
-      options: --device=/dev/mem --device=/dev/dri --group-add video --security-opt seccomp=unconfined --cap-add=SYS_PTRACE --shm-size=8g
-              -u ${{ needs.runner.outputs.user_id }}:${{ needs.runner.outputs.render_id }}
+      options: >-
+        --device=/dev/mem
+        --device=/dev/dri
+        --group-add video
+        --security-opt seccomp=unconfined
+        --cap-add=SYS_PTRACE
+        --shm-size=8g
+        -u ${{ needs.runner.outputs.user_id }}:${{ needs.runner.outputs.render_id }}
       env:
         AGENT_TOOLSDIRECTORY: /opt/xpu-tool
     steps:
       - name: Checkout torch-xpu-ops
         uses: actions/checkout@v6
+
       - name: Prepare test env
         uses: ./.github/actions/linux-testenv
         with:
           pytorch: ${{ inputs.pytorch }}
           python: ${{ inputs.python }}
+
       - name: Run Torch XPU Op Benchmark on ${{ needs.runner.outputs.hostname }}
-        run: |
-          mkdir -p ${{ github.workspace }}/op_benchmark
-          cd test/microbench
-          filename=$(find -- *.py)
-          for i in $filename
-          do
-            python ${i%.*}.py > ${{ github.workspace }}/op_benchmark/${i%.*}.log
-          done
-          pip install pandas openpyxl
-          # Summary forward op time
-          python ${{ github.workspace }}/.github/scripts/microbench_summary.py ${{ github.workspace }}/op_benchmark ${{ github.workspace }}/op_benchmark/forward_op_summary.csv
-          # Summary backward op time
-          python ${{ github.workspace }}/.github/scripts/microbench_summary.py ${{ github.workspace }}/op_benchmark ${{ github.workspace }}/op_benchmark/backward_op_summary.csv --backward
-      - name: Upload Inductor XPU OP benchmark Log
+        uses: ./.github/actions/run-microbench
+
+      - name: Upload microbench artifact
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: Inductor-XPU-OP-Benchmark-Data-${{ github.event.pull_request.number || github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ github.workspace }}/op_benchmark
+          if-no-files-found: warn
 
+  # ── Compare vs baseline + update reference issue ──────────────────────────
   op_benchmark_test_results_check:
     needs: op_benchmark
     runs-on: ubuntu-24.04
@@ -99,66 +108,34 @@ jobs:
     steps:
       - name: Install gh-cli
         run: |
-          sudo apt-get update
-          sudo apt-get install gh rsync ca-certificates -y
+          sudo apt-get update -qq
+          sudo apt-get install -y gh rsync ca-certificates
+
       - name: Checkout torch-xpu-ops
         uses: actions/checkout@v6
+
       - name: Setup python-${{ inputs.python }}
         uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python }}
-      - name: Download XPU UT Logs
+
+      - name: Download current run artifacts
         uses: actions/download-artifact@v8
         with:
           pattern: Inductor-XPU-OP-Benchmark-Data-${{ github.event.pull_request.number || github.sha }}-*
           path: ${{ github.workspace }}/op_benchmark_tmp
-      - name: Download OP Baseline
-        continue-on-error: true
-        id: reference_id
-        run: |
-          # latest dir
-          latest_dir=$(find . -type d -name "Inductor-XPU-OP-Benchmark-Data-${{ github.event.pull_request.number || github.sha }}-*" |sort -V |tail -n 1)
-          mv ${{ github.workspace }}/op_benchmark_tmp/${latest_dir} ${{ github.workspace }}/op_benchmark
-          # baseline
-          REFERENCE_RUN_ID="$(gh --repo ${GITHUB_REPOSITORY} issue view ${reference_issue} \
-            --json body -q .body |grep "Inductor-XPU-OP-Benchmark-Data" |sed 's/.*: *//')"
-          gh --repo ${GITHUB_REPOSITORY} run download ${REFERENCE_RUN_ID} -p "Inductor-XPU-OP-Benchmark-Data-*"
-          rm -rf ${{ github.workspace }}/reference
-          mkdir -p ${{ github.workspace }}/reference
-          mv -f Inductor-XPU-OP-Benchmark-Data-*-Updated/* ${{ github.workspace }}/reference
 
-          mkdir -p ${{ github.workspace }}/baseline
-          if [[ -f "${{ github.workspace }}/reference/new_baseline/baseline_forward_op_summary.csv" ]]; then
-            cp ${{ github.workspace }}/reference/new_baseline/baseline_forward_op_summary.csv ${{ github.workspace }}/baseline
-            cp ${{ github.workspace }}/reference/new_baseline/baseline_backward_op_summary.csv ${{ github.workspace }}/baseline
-          else
-            cp ${{ github.workspace }}/reference/forward_op_summary.csv ${{ github.workspace }}/baseline/baseline_forward_op_summary.csv
-            cp ${{ github.workspace }}/reference/backward_op_summary.csv ${{ github.workspace }}/baseline/baseline_backward_op_summary.csv
-          fi
-      - name: Check the OP Regression
-        run: |
-          pip install tabulate pandas
-          # Compare forward op
-          python ${{ github.workspace }}/.github/scripts/op_perf_comparison.py --xpu_file ${{ github.workspace }}/op_benchmark/forward_op_summary.csv --baseline_file ${{ github.workspace }}/baseline/baseline_forward_op_summary.csv
-          # Compare backward op
-          python ${{ github.workspace }}/.github/scripts/op_perf_comparison.py --xpu_file ${{ github.workspace }}/op_benchmark/backward_op_summary.csv --baseline_file ${{ github.workspace }}/baseline/baseline_backward_op_summary.csv
-      - name: Update OP Baseline
-        run: |
-          mkdir ${{ github.workspace }}/new_baseline
-          cp ${{ github.workspace }}/baseline/baseline*.csv ${{ github.workspace }}/new_baseline
-          # Update forward op
-          python ${{ github.workspace }}/.github/scripts/op_calculate_best_perf.py --xpu ${{ github.workspace }}/op_benchmark/forward_op_summary.csv --baseline ${{ github.workspace }}/new_baseline/baseline_forward_op_summary.csv -r
-          # Update backward op
-          python ${{ github.workspace }}/.github/scripts/op_calculate_best_perf.py --xpu ${{ github.workspace }}/op_benchmark/backward_op_summary.csv --baseline ${{ github.workspace }}/new_baseline/baseline_backward_op_summary.csv -r
-          cp -r ${{ github.workspace }}/new_baseline ${{ github.workspace }}/op_benchmark
-      - name: Upload Inductor XPU OP benchmark Log
+      - name: Compare against baseline
+        uses: ./.github/actions/compare-microbench
+        with:
+          reference-issue: ${{ inputs.reference_issue }}
+          artifact-dir: ${{ github.workspace }}/op_benchmark_tmp
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload updated baseline
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: Inductor-XPU-OP-Benchmark-Data-${{ github.event.pull_request.number || github.sha }}-Updated-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ github.workspace }}/op_benchmark
-      - name: Upload Reference Run ID
-        run: |
-          gh --repo ${GITHUB_REPOSITORY} issue view ${reference_issue} --json body -q .body | \
-            sed "s/Inductor-XPU-OP-Benchmark-Data:.*/Inductor-XPU-OP-Benchmark-Data: ${GITHUB_RUN_ID}/" | sed '/^$/d' > new_body.txt
-          gh --repo ${GITHUB_REPOSITORY} issue edit ${reference_issue} --body-file new_body.txt
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary

Sixth PR in the CI/CD refactor series. Decomposes `_linux_op_benchmark.yml` into reusable scripts/actions and makes the reference-issue id configurable.

> **Stacked on:** #15 - Refactor distributed (#15 -> #14 -> #13 -> #12 -> #11). Review/merge those first.

## Why

`_linux_op_benchmark.yml` had:
- Two large inline `run:` blocks (run microbench + compare-against-baseline + update reference issue).
- A hardcoded reference issue number (`1689`) baked into a workflow-level `env:` value.
- A hard failure path on missing baseline (first-ever run on a new fork) and on individual microbench-script failures.

## Changes

### New scripts

```
.ci/scripts/microbench/
  run.sh                        run every test/microbench/*.py and emit
                                forward/backward summary CSVs
  fetch_baseline.sh             resolve baseline run id from the reference
                                issue body, download artifacts, stage
                                baseline_*.csv (warns and exits 0 on missing)
  compare.sh                    op_perf_comparison.py + best-of baseline
                                update via op_calculate_best_perf.py
                                (no-op when no baseline is staged)
  update_reference_issue.sh     overwrite the reference-issue body with
                                this run id (best-effort)
```

### New composite actions

| Action | Purpose |
|---|---|
| `run-microbench` | Thin wrapper around `run.sh`. |
| `compare-microbench` | Wraps `fetch_baseline.sh` + `compare.sh` + `update_reference_issue.sh`. Takes `reference-issue` and `github-token` inputs; `update-reference-issue` flag for non-baseline runs. |

### Workflow

`_linux_op_benchmark.yml`: 164 -> 141 lines. New inputs:
- `reference_issue` (default `1689` - same as before)
- `docker_image_name` (default unchanged)

The two large inline `run:` blocks collapse to one composite-action step each.

## Behavior

- One microbench script failing no longer aborts the suite (warn + continue); the comparison step still decides whether the run is passing.
- First-ever run on a fork no longer hard-fails on missing baseline; it warns, skips comparison, and uploads its result so the next run has something to compare against.
- Same artifact names. Same baseline-update protocol (`*-Updated` artifact + reference-issue body edit).

Net: 7 files changed, **+322 / -67**.

## Roadmap

- PR 1: code check (#11)
- PR 2: build (#12)
- PR 3: dynamo benchmark / E2E (#13)
- PR 4: unit tests (#14)
- PR 5: distributed tests (#15)
- **PR 6: microbench (this)**
- Next: accelerate, transformers, Windows UT parity, unified reporting.
