### PR TITLE
Refactor accelerate: extract pytest runner + reusable summary

### DIFF
--- a/.ci/scripts/accelerate/run.sh
+++ b/.ci/scripts/accelerate/run.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Run the Accelerate XPU pytest suite with project-known exclusions and
+# emit a JUnit XML at $REPORT_PATH.
+#
+# Inputs (env):
+#   ACCELERATE_DIR   path to the accelerate checkout (default: $GITHUB_WORKSPACE/accelerate)
+#   REPORT_PATH      JUnit XML output path (default: $ACCELERATE_DIR/reports/accelerate.xml)
+
+set -euo pipefail
+
+: "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}"
+ACCELERATE_DIR="${ACCELERATE_DIR:-${GITHUB_WORKSPACE}/accelerate}"
+REPORT_PATH="${REPORT_PATH:-${ACCELERATE_DIR}/reports/accelerate.xml}"
+
+cd "${ACCELERATE_DIR}"
+mkdir -p "$(dirname "${REPORT_PATH}")"
+
+# Excluded tests:
+#   * test_profiler                    - PTI_ERROR_INTERNAL on Kineto init for XPU
+#   * test_gated                       - flaky env-config issue (HF gated repos)
+#   * test_dispatch_model_..._offload  - OOM on huggingface/accelerate#3445
+PATTERN="not test_profiler and not test_gated and not test_dispatch_model_tied_weights_memory_with_nested_offload_cpu"
+
+cmd=(python -m pytest --junitxml="${REPORT_PATH}" -k "${PATTERN}" tests/)
+
+# Echo the command into the step summary if available.
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+        echo "### Running"
+        echo '```'
+        echo "${cmd[@]@Q}"
+        echo '```'
+    } >> "${GITHUB_STEP_SUMMARY}"
+fi
+
+"${cmd[@]}"

--- a/.github/actions/summarize-junit/action.yml
+++ b/.github/actions/summarize-junit/action.yml
@@ -1,0 +1,59 @@
+name: Summarize JUnit XML
+description: >-
+  Parse a JUnit XML file with .github/scripts/parse-junitxml.py and emit
+  Stats / Failed / Skipped sections to the GitHub step summary. Best-effort:
+  parsing errors do not fail the step.
+
+inputs:
+  report:
+    required: true
+    description: Path to the JUnit XML file.
+  parser:
+    required: false
+    default: ${{ github.workspace }}/torch-xpu-ops/.github/scripts/parse-junitxml.py
+    description: Path to parse-junitxml.py.
+  title:
+    required: false
+    default: 'Test Results'
+    description: H3 heading used in the step summary.
+  fail-on-failure:
+    required: false
+    default: 'false'
+    description: When 'true', fail the step if any test failed or errored.
+
+runs:
+  using: composite
+  steps:
+    - name: Emit step summary
+      shell: bash {0}
+      env:
+        REPORT: ${{ inputs.report }}
+        PARSER: ${{ inputs.parser }}
+        TITLE: ${{ inputs.title }}
+        FAIL_ON: ${{ inputs.fail-on-failure }}
+      run: |
+        if [[ ! -f "${REPORT}" ]]; then
+          echo "::warning::no JUnit report at ${REPORT}"
+          exit 0
+        fi
+        if [[ ! -f "${PARSER}" ]]; then
+          echo "::warning::parse-junitxml.py not found at ${PARSER}"
+          exit 0
+        fi
+
+        if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+          {
+            echo "### ${TITLE} - Results"
+            python "${PARSER}" "${REPORT}" --stats || true
+            echo "### ${TITLE} - Failed"
+            python "${PARSER}" "${REPORT}" --errors --failed || true
+            echo "### ${TITLE} - Skipped"
+            python "${PARSER}" "${REPORT}" --skipped || true
+          } >> "${GITHUB_STEP_SUMMARY}"
+        fi
+
+        if [[ "${FAIL_ON}" == "true" ]]; then
+          # parse-junitxml.py prints a non-zero exit when there are failures
+          # under --strict (project convention). Re-run for the gating signal.
+          python "${PARSER}" "${REPORT}" --errors --failed --strict || exit 1
+        fi

--- a/.github/workflows/_linux_accelerate.yml
+++ b/.github/workflows/_linux_accelerate.yml
@@ -10,7 +10,9 @@ on:
     paths:
       - '.github/scripts/parse-junitxml.py'
       - '.github/actions/print-environment/action.yml'
+      - '.github/actions/summarize-junit/action.yml'
       - '.github/workflows/_linux_accelerate.yml'
+      - '.ci/scripts/accelerate/**'
   workflow_dispatch:
     inputs:
       pytorch:
@@ -38,6 +40,11 @@ on:
         type: string
         default: 'v4.51.3'
         description: Transformers version
+      docker_image_name:
+        required: false
+        type: string
+        default: 'intelgpu/ubuntu-24.04-lts2:2523.40'
+        description: Docker image for the test container
 
 permissions: read-all
 
@@ -48,9 +55,14 @@ concurrency:
 defaults:
   run:
     shell: bash {0}
+
 env:
   GH_TOKEN: ${{ github.token }}
   DOCKER_REGISTRY_AUTH_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
+  ACCELERATE_REF: ${{ inputs.accelerate != '' && inputs.accelerate || 'v1.6.0' }}
+  TRANSFORMERS_REF: ${{ inputs.transformers != '' && inputs.transformers || 'v4.51.3' }}
+  PYTHON_VERSION: ${{ inputs.python != '' && inputs.python || '3.10' }}
+  DOCKER_IMAGE: ${{ inputs.docker_image_name != '' && inputs.docker_image_name || 'intelgpu/ubuntu-24.04-lts2:2523.40' }}
 
 jobs:
   prepare:
@@ -60,10 +72,10 @@ jobs:
       && !contains(github.event.pull_request.labels.*.name, 'disable_all')
       && !contains(github.event.pull_request.labels.*.name, 'disable_accelerate')
     outputs:
-      runner_id: ${{ steps.runner-info.outputs.runner_id }}
-      user_id: ${{ steps.runner-info.outputs.user_id }}
-      render_id: ${{ steps.runner-info.outputs.render_id }}
-      hostname: ${{ steps.runner-info.outputs.hostname }}
+      runner_id:         ${{ steps.runner-info.outputs.runner_id }}
+      user_id:           ${{ steps.runner-info.outputs.user_id }}
+      render_id:         ${{ steps.runner-info.outputs.render_id }}
+      hostname:          ${{ steps.runner-info.outputs.hostname }}
       pytest_extra_args: ${{ steps.runner-info.outputs.pytest_extra_args }}
     steps:
       - name: Checkout torch-xpu-ops
@@ -76,115 +88,102 @@ jobs:
     runs-on: ${{ needs.prepare.outputs.runner_id }}
     needs: prepare
     container:
-      image: intelgpu/ubuntu-24.04-lts2:2523.40
+      image: ${{ env.DOCKER_IMAGE }}
       volumes:
         - ${{ github.workspace }}:${{ github.workspace }}
-      options: --device=/dev/mem --device=/dev/dri --group-add video --group-add ${{ needs.prepare.outputs.render_id }}
-              --security-opt seccomp=unconfined --cap-add=SYS_PTRACE --shm-size=8g
-              -u ${{ needs.prepare.outputs.user_id }}
-              -e ZE_AFFINITY_MASK
+      options: >-
+        --device=/dev/mem
+        --device=/dev/dri
+        --group-add video
+        --group-add ${{ needs.prepare.outputs.render_id }}
+        --security-opt seccomp=unconfined
+        --cap-add=SYS_PTRACE
+        --shm-size=8g
+        -u ${{ needs.prepare.outputs.user_id }}
+        -e ZE_AFFINITY_MASK
       env:
         WORK_DIR: 'accelerate'
         PYTORCH_DEBUG_XPU_FALLBACK: 1
         HF_HUB_ETAG_TIMEOUT: 120
         HF_HUB_DOWNLOAD_TIMEOUT: 120
-        PARSE_JUNIT: ${{ github.workspace }}/torch-xpu-ops/.github/scripts/parse-junitxml.py
         AGENT_TOOLSDIRECTORY: /tmp/xpu-tool
         PYTEST_ADDOPTS: -rsf --timeout 600 --timeout_method=thread --dist worksteal ${{ needs.prepare.outputs.pytest_extra_args }}
-    env:
-      accelerate: ${{ inputs.accelerate != '' && inputs.accelerate || 'v1.6.0' }}
-      transformers: ${{ inputs.transformers != '' && inputs.transformers || 'v4.51.3' }}
-      python: ${{ inputs.python != '' && inputs.python || '3.10' }}
     steps:
       - name: Checkout torch-xpu-ops
         uses: actions/checkout@v6
         with:
           path: torch-xpu-ops
+
       - name: Checkout Accelerate
         uses: actions/checkout@v6
         with:
           repository: huggingface/accelerate
-          ref: ${{ env.accelerate }}
+          ref: ${{ env.ACCELERATE_REF }}
           path: accelerate
-      - name: Setup python-${{ env.python }}
+
+      - name: Setup python-${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ env.python }}
-      - name: Check python
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Check python and install pytorch
         run: |
           which python && python -V
           which pip && pip list
           pip install -U pip wheel setuptools
-      - name: Install pytorch and deps
-        run: |
           pip install junitparser
-          pip install transformers==${{ env.transformers }}
+          pip install transformers==${{ env.TRANSFORMERS_REF }}
           pip install torch torchvision torchaudio --pre --index-url https://download.pytorch.org/whl/nightly/xpu
+
       - name: Prepare Accelerate
         run: |
-          cd $WORK_DIR
+          cd "$WORK_DIR"
           pip install -e .
           pip install -e ".[testing]"
-          rm -rf tests_log && mkdir -p tests_log
-          rm -rf reports
-          cp ${{ github.workspace }}/torch-xpu-ops/.github/scripts/spec.py ./
+          rm -rf tests_log reports
+          mkdir -p tests_log
+          cp "${{ github.workspace }}/torch-xpu-ops/.github/scripts/spec.py" ./
+
       - name: Report installed versions
         run: |
           echo "pip installed packages:"
-          pip list | tee ${{ github.workspace }}/$WORK_DIR/tests_log/pip_list.txt
+          pip list | tee "${{ github.workspace }}/$WORK_DIR/tests_log/pip_list.txt"
           echo "lspci gpu devices:"
-          lspci -d ::0380 | tee ${{ github.workspace }}/$WORK_DIR/tests_log/lspci_0380.txt
+          lspci -d ::0380 | tee "${{ github.workspace }}/$WORK_DIR/tests_log/lspci_0380.txt"
           echo "GPU render nodes:"
-          cat /sys/class/drm/render*/device/device | tee ${{ github.workspace }}/$WORK_DIR/tests_log/device_IDs.txt
+          cat /sys/class/drm/render*/device/device | tee "${{ github.workspace }}/$WORK_DIR/tests_log/device_IDs.txt"
           echo "xpu-smi output:"
           xpu-smi discovery -y --json --dump -1
+
       - name: Sanity check installed packages
         run: |
           # Use latest pytest
           pip install -U pytest pytest-timeout pytest-xdist
-          # These checks are to exit earlier if for any reason torch
-          # packages were reinstalled back to CUDA versions (not expected).
-          pip show torch | grep Version | grep xpu
-          pip show torchaudio | grep Version | grep xpu
+          # Bail out early if torch packages were re-resolved to non-xpu wheels.
+          pip show torch       | grep Version | grep xpu
+          pip show torchaudio  | grep Version | grep xpu
           pip show torchvision | grep Version | grep xpu
           python -c 'import torch; exit(not torch.xpu.is_available())'
           printenv
+
       - name: Run tests on ${{ needs.prepare.outputs.hostname }}
         run: |
-          cd $WORK_DIR && rm -rf reports && mkdir -p reports
-          # Excluding tests due to:
-          # * tests/test_examples.py::FeatureExamplesTests::test_profiler fails on
-          #   Kineto profiler initialization for XPU device: PTI_ERROR_INTERNAL
-          # * tests/test_cli.py::ModelEstimatorTester::test_gated for failures due
-          #   to not root caused environment configuration issue
-          # * tests/test_big_modeling.py::test_dispatch_model_tied_weights_memory_with_nested_offload_cpu fails
-          #   with OOM. That's a new test added by https://github.com/huggingface/accelerate/pull/3445
-          pattern="not test_profiler and not test_gated and not test_dispatch_model_tied_weights_memory_with_nested_offload_cpu"
-          cmd=(python -m pytest --junitxml=reports/accelerate.xml -k "$pattern" tests/)
-          {
-            echo "### Running"
-            echo "\`\`\`"
-            echo "${cmd[@]@Q}"
-            echo "\`\`\`"
-          } >> $GITHUB_STEP_SUMMARY
-          "${cmd[@]}"
+          bash "${{ github.workspace }}/torch-xpu-ops/.ci/scripts/accelerate/run.sh"
+
       - name: Print result tables
         if: ${{ ! cancelled() }}
-        run: |
-          cd $WORK_DIR
-          {
-            echo "### Results"
-            python $PARSE_JUNIT reports/accelerate.xml --stats
-            echo "### Failed"
-            python $PARSE_JUNIT reports/accelerate.xml --errors --failed
-            echo "### Skipped"
-            python $PARSE_JUNIT reports/accelerate.xml --skipped
-          } >> $GITHUB_STEP_SUMMARY
+        uses: ./torch-xpu-ops/.github/actions/summarize-junit
+        with:
+          report: ${{ github.workspace }}/accelerate/reports/accelerate.xml
+          parser: ${{ github.workspace }}/torch-xpu-ops/.github/scripts/parse-junitxml.py
+          title: 'Accelerate'
+
       - name: Print environment
         if: ${{ ! cancelled() }}
         uses: ./torch-xpu-ops/.github/actions/print-environment
         with:
           pip_packages: 'accelerate transformers'
+
       - name: Upload Test log
         if: ${{ ! cancelled() }}
         uses: actions/upload-artifact@v7
@@ -193,3 +192,4 @@ jobs:
           path: |
             ${{ github.workspace }}/accelerate/reports
             ${{ github.workspace }}/accelerate/tests_log
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary

Seventh PR in the CI/CD refactor series. Lifts the accelerate pytest invocation and the JUnit-summary boilerplate out of `_linux_accelerate.yml` into reusable building blocks. The new `summarize-junit` action will be reused by the next PR (transformers).

> **Stacked on:** #16 - Refactor microbench (#16 -> #15 -> #14 -> #13 -> #12 -> #11). Review/merge those first.

## Why

`_linux_accelerate.yml` had:
- A 20-line inline `Run tests` step that hardcoded the pytest pattern and its three project-known exclusions.
- A handwritten `Print result tables` step that re-implemented the same `parse-junitxml.py` wrapper that the transformers pipeline also wants.
- A docker-image string baked into the container `image:` field.

## Changes

### New script

```
.ci/scripts/accelerate/run.sh   run the accelerate XPU pytest suite
                                with project-known exclusions and emit
                                a JUnit XML
```

Excluded tests are documented inline:
- `test_profiler` - PTI_ERROR_INTERNAL on Kineto init for XPU
- `test_gated` - HF gated-repo env-config flakiness
- `test_dispatch_model_..._offload` - OOM (huggingface/accelerate#3445)

### New composite action

`summarize-junit` wraps `.github/scripts/parse-junitxml.py` and emits Stats / Failed / Skipped sections to `$GITHUB_STEP_SUMMARY`. Inputs:

| Input | Default | Purpose |
|---|---|---|
| `report` | (required) | path to JUnit XML |
| `parser` | `${{ github.workspace }}/torch-xpu-ops/.github/scripts/parse-junitxml.py` | parser script |
| `title` | `Test Results` | H3 heading prefix |
| `fail-on-failure` | `false` | gate the step on failures |

### Refactored workflow

`_linux_accelerate.yml`:
- New `docker_image_name` input (default unchanged).
- `Run tests` step replaced with one bash line invoking the script.
- `Print result tables` step replaced by `summarize-junit`.
- `paths:` filter updated for the new files.

## Behavior

Identical: same docker image default, same accelerate / transformers default versions, same exclusion list, same artifact name and contents (`reports/` + `tests_log/`), same step-summary structure.

Net: 3 files changed, **+154 / -59**.

## Roadmap

- PR 1: code check (#11)
- PR 2: build (#12)
- PR 3: dynamo benchmark / E2E (#13)
- PR 4: unit tests (#14)
- PR 5: distributed tests (#15)
- PR 6: microbench (#16)
- **PR 7: accelerate (this)**
- Next: transformers (will reuse `summarize-junit`), Windows UT parity, unified reporting.
